### PR TITLE
Fix long tags being truncated to ellipsis only 

### DIFF
--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -5,6 +5,7 @@ import java.util.stream.Collectors;
 
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
+import javafx.scene.control.Tooltip;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
@@ -49,7 +50,14 @@ public class PersonCard extends UiPart<Region> {
         name.setText(person.getName().fullName);
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
-                .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
+                .forEach(tag -> {
+                    Label tagLabel = new Label(tag.tagName);
+                    tagLabel.setMaxWidth(100);
+                    Tooltip tooltip = new Tooltip(tag.tagName);
+                    tooltip.setShowDelay(javafx.util.Duration.millis(100));
+                    tagLabel.setTooltip(tooltip);
+                    tags.getChildren().add(tagLabel);
+                });
         person.getGames().stream()
                 .sorted(Comparator.comparing(game -> game.gameName))
                 .forEach(game -> {

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -345,6 +345,8 @@
     -fx-border-radius: 2;
     -fx-background-radius: 2;
     -fx-font-size: 11;
+    -fx-max-width: 100px;
+    -fx-text-overrun: ellipsis;
 }
 
 #games .game-label {


### PR DESCRIPTION
 ### Problem                                                  
  Tags with long names were not being truncated and occupying alot of space

### Fix         
  - Capped tag label width at 100px with ellipsis truncation   
  - Added a tooltip that displays the full tag name on hover   
  (shows after 100ms)                                          
  - Applied `-fx-max-width` and `-fx-text-overrun: ellipsis` in   CSS for consistent styling
                                                   
  ### Files Changed                                              
- `src/main/java/seedu/address/ui/PersonCard.java`
- `src/main/resources/view/DarkTheme.css`                    
                  
  ### Testing                                                  
  - [x] Tags with long names truncate cleanly with `...`
  - [x] Hovering over a truncated tag shows the full tag name  
  - [x] Short tags display normally without truncation         
  - [x] Existing tag styling is unchanged
  
  CLOSES #63 