### PR TITLE
Extend find command to support search by game and alias

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -2,27 +2,31 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.function.Predicate;
+
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.model.Model;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.Person;
 
 /**
- * Finds and lists all persons in address book whose name contains any of the argument keywords.
- * Keyword matching is case insensitive.
+ * Finds and lists all persons in address book matching the given predicate.
+ * Supports search by name, game, or alias.
  */
 public class FindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names contain any of "
-            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
-            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
-            + "Example: " + COMMAND_WORD + " alice bob charlie";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons matching the search criteria "
+            + "(case-insensitive) and displays them as a list with index numbers.\n"
+            + "Parameters: KEYWORD [MORE_KEYWORDS]... | g/GAME_NAME | al/ALIAS\n"
+            + "Example: " + COMMAND_WORD + " alice bob\n"
+            + "Example: " + COMMAND_WORD + " g/Valorant\n"
+            + "Example: " + COMMAND_WORD + " al/BenJumpin";
 
-    private final NameContainsKeywordsPredicate predicate;
+    private final Predicate<Person> predicate;
 
-    public FindCommand(NameContainsKeywordsPredicate predicate) {
+    public FindCommand(Predicate<Person> predicate) {
         this.predicate = predicate;
     }
 
@@ -40,7 +44,6 @@ public class FindCommand extends Command {
             return true;
         }
 
-        // instanceof handles nulls
         if (!(other instanceof FindCommand)) {
             return false;
         }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -1,15 +1,19 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ALIAS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_GAME;
 
 import java.util.Arrays;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.AliasMatchesPredicate;
+import seedu.address.model.person.GameContainsKeywordPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 
 /**
- * Parses input arguments and creates a new FindCommand object
+ * Parses input arguments and creates a new FindCommand object.
  */
 public class FindCommandParser implements Parser<FindCommand> {
 
@@ -26,9 +30,25 @@ public class FindCommandParser implements Parser<FindCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
-        String[] nameKeywords = trimmedArgs.split("\\s+");
+        if (trimmedArgs.startsWith(PREFIX_GAME.getPrefix())) {
+            String keyword = trimmedArgs.substring(PREFIX_GAME.getPrefix().length()).trim();
+            if (keyword.isEmpty()) {
+                throw new ParseException(
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+            }
+            return new FindCommand(new GameContainsKeywordPredicate(keyword));
+        }
 
+        if (trimmedArgs.startsWith(PREFIX_ALIAS.getPrefix())) {
+            String keyword = trimmedArgs.substring(PREFIX_ALIAS.getPrefix().length()).trim();
+            if (keyword.isEmpty()) {
+                throw new ParseException(
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+            }
+            return new FindCommand(new AliasMatchesPredicate(keyword));
+        }
+
+        String[] nameKeywords = trimmedArgs.split("\\s+");
         return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
     }
-
 }

--- a/src/main/java/seedu/address/model/person/AliasMatchesPredicate.java
+++ b/src/main/java/seedu/address/model/person/AliasMatchesPredicate.java
@@ -1,0 +1,42 @@
+package seedu.address.model.person;
+
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.ToStringBuilder;
+
+/**
+ * Tests that a {@code Person} has an alias that matches the given keyword (case-insensitive).
+ */
+public class AliasMatchesPredicate implements Predicate<Person> {
+    private final String keyword;
+
+    public AliasMatchesPredicate(String keyword) {
+        this.keyword = keyword;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return person.getGames().stream()
+                .flatMap(game -> game.getAliases().stream())
+                .anyMatch(alias -> alias.value.equalsIgnoreCase(keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof AliasMatchesPredicate)) {
+            return false;
+        }
+
+        AliasMatchesPredicate otherPredicate = (AliasMatchesPredicate) other;
+        return keyword.equalsIgnoreCase(otherPredicate.keyword);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("keyword", keyword).toString();
+    }
+}

--- a/src/main/java/seedu/address/model/person/GameContainsKeywordPredicate.java
+++ b/src/main/java/seedu/address/model/person/GameContainsKeywordPredicate.java
@@ -1,0 +1,41 @@
+package seedu.address.model.person;
+
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.ToStringBuilder;
+
+/**
+ * Tests that a {@code Person} has a game whose name matches the given keyword (case-insensitive).
+ */
+public class GameContainsKeywordPredicate implements Predicate<Person> {
+    private final String keyword;
+
+    public GameContainsKeywordPredicate(String keyword) {
+        this.keyword = keyword;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return person.getGames().stream()
+                .anyMatch(game -> game.gameName.equalsIgnoreCase(keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof GameContainsKeywordPredicate)) {
+            return false;
+        }
+
+        GameContainsKeywordPredicate otherPredicate = (GameContainsKeywordPredicate) other;
+        return keyword.equalsIgnoreCase(otherPredicate.keyword);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("keyword", keyword).toString();
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -18,6 +18,8 @@ import org.junit.jupiter.api.Test;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.person.AliasMatchesPredicate;
+import seedu.address.model.person.GameContainsKeywordPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 
 /**
@@ -50,7 +52,7 @@ public class FindCommandTest {
         // null -> returns false
         assertFalse(findFirstCommand.equals(null));
 
-        // different person -> returns false
+        // different predicate -> returns false
         assertFalse(findFirstCommand.equals(findSecondCommand));
     }
 
@@ -72,6 +74,26 @@ public class FindCommandTest {
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_gameKeyword_noPersonFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        GameContainsKeywordPredicate predicate = new GameContainsKeywordPredicate("Valorant");
+        FindCommand command = new FindCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_aliasKeyword_noPersonFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        AliasMatchesPredicate predicate = new AliasMatchesPredicate("BenJumpin");
+        FindCommand command = new FindCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredPersonList());
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -9,6 +9,8 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.FindCommand;
+import seedu.address.model.person.AliasMatchesPredicate;
+import seedu.address.model.person.GameContainsKeywordPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 
 public class FindCommandParserTest {
@@ -21,8 +23,7 @@ public class FindCommandParserTest {
     }
 
     @Test
-    public void parse_validArgs_returnsFindCommand() {
-        // no leading and trailing whitespaces
+    public void parse_validNameArgs_returnsFindCommand() {
         FindCommand expectedFindCommand =
                 new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
         assertParseSuccess(parser, "Alice Bob", expectedFindCommand);
@@ -31,4 +32,31 @@ public class FindCommandParserTest {
         assertParseSuccess(parser, " \n Alice \n \t Bob  \t", expectedFindCommand);
     }
 
+    @Test
+    public void parse_validGamePrefix_returnsFindCommand() {
+        FindCommand expectedFindCommand = new FindCommand(new GameContainsKeywordPredicate("Valorant"));
+        assertParseSuccess(parser, "g/Valorant", expectedFindCommand);
+
+        // with leading whitespace
+        assertParseSuccess(parser, " g/Valorant", expectedFindCommand);
+    }
+
+    @Test
+    public void parse_emptyGamePrefix_throwsParseException() {
+        assertParseFailure(parser, "g/", String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_validAliasPrefix_returnsFindCommand() {
+        FindCommand expectedFindCommand = new FindCommand(new AliasMatchesPredicate("BenJumpin"));
+        assertParseSuccess(parser, "al/BenJumpin", expectedFindCommand);
+
+        // with leading whitespace
+        assertParseSuccess(parser, " al/BenJumpin", expectedFindCommand);
+    }
+
+    @Test
+    public void parse_emptyAliasPrefix_throwsParseException() {
+        assertParseFailure(parser, "al/", String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+    }
 }

--- a/src/test/java/seedu/address/model/person/AliasMatchesPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/AliasMatchesPredicateTest.java
@@ -1,0 +1,75 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.game.Game;
+import seedu.address.testutil.PersonBuilder;
+
+public class AliasMatchesPredicateTest {
+
+    private Person buildPersonWithAlias(String name, String gameName, String aliasValue) {
+        Set<Alias> aliases = new HashSet<>();
+        aliases.add(new Alias(aliasValue));
+        Set<Game> games = new HashSet<>();
+        games.add(new Game(gameName, aliases));
+        return new Person(new Name(name), new HashSet<>(), games);
+    }
+
+    @Test
+    public void equals() {
+        AliasMatchesPredicate firstPredicate = new AliasMatchesPredicate("BenJumpin");
+        AliasMatchesPredicate secondPredicate = new AliasMatchesPredicate("AlicePlays");
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same value -> returns true
+        assertTrue(firstPredicate.equals(new AliasMatchesPredicate("BenJumpin")));
+
+        // case-insensitive same value -> returns true
+        assertTrue(firstPredicate.equals(new AliasMatchesPredicate("benjumpin")));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different keyword -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_personHasMatchingAlias_returnsTrue() {
+        AliasMatchesPredicate predicate = new AliasMatchesPredicate("BenJumpin");
+        assertTrue(predicate.test(buildPersonWithAlias("Ben", "Valorant", "BenJumpin")));
+
+        // case-insensitive match
+        predicate = new AliasMatchesPredicate("benjumpin");
+        assertTrue(predicate.test(buildPersonWithAlias("Ben", "Valorant", "BenJumpin")));
+    }
+
+    @Test
+    public void test_personDoesNotHaveMatchingAlias_returnsFalse() {
+        // no games
+        AliasMatchesPredicate predicate = new AliasMatchesPredicate("BenJumpin");
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice").build()));
+
+        // game exists but no matching alias
+        assertFalse(predicate.test(buildPersonWithAlias("Alice", "Valorant", "AlicePlays")));
+    }
+
+    @Test
+    public void toStringMethod() {
+        AliasMatchesPredicate predicate = new AliasMatchesPredicate("BenJumpin");
+        String expected = AliasMatchesPredicate.class.getCanonicalName() + "{keyword=BenJumpin}";
+        assertEquals(expected, predicate.toString());
+    }
+}

--- a/src/test/java/seedu/address/model/person/GameContainsKeywordPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/GameContainsKeywordPredicateTest.java
@@ -1,0 +1,67 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.PersonBuilder;
+
+public class GameContainsKeywordPredicateTest {
+
+    @Test
+    public void equals() {
+        GameContainsKeywordPredicate firstPredicate = new GameContainsKeywordPredicate("Valorant");
+        GameContainsKeywordPredicate secondPredicate = new GameContainsKeywordPredicate("Minecraft");
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same value -> returns true
+        assertTrue(firstPredicate.equals(new GameContainsKeywordPredicate("Valorant")));
+
+        // case-insensitive same value -> returns true
+        assertTrue(firstPredicate.equals(new GameContainsKeywordPredicate("valorant")));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different keyword -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_personHasMatchingGame_returnsTrue() {
+        GameContainsKeywordPredicate predicate = new GameContainsKeywordPredicate("Valorant");
+        assertTrue(predicate.test(new PersonBuilder().withName("Alice").withGames("Valorant").build()));
+
+        // case-insensitive match
+        predicate = new GameContainsKeywordPredicate("valorant");
+        assertTrue(predicate.test(new PersonBuilder().withName("Alice").withGames("Valorant").build()));
+
+        // person with multiple games
+        predicate = new GameContainsKeywordPredicate("Minecraft");
+        assertTrue(predicate.test(new PersonBuilder().withName("Bob").withGames("Valorant", "Minecraft").build()));
+    }
+
+    @Test
+    public void test_personDoesNotHaveMatchingGame_returnsFalse() {
+        // no games
+        GameContainsKeywordPredicate predicate = new GameContainsKeywordPredicate("Valorant");
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice").build()));
+
+        // different game
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withGames("Minecraft").build()));
+    }
+
+    @Test
+    public void toStringMethod() {
+        GameContainsKeywordPredicate predicate = new GameContainsKeywordPredicate("Valorant");
+        String expected = GameContainsKeywordPredicate.class.getCanonicalName() + "{keyword=Valorant}";
+        assertEquals(expected, predicate.toString());
+    }
+}

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -1,7 +1,9 @@
 package seedu.address.testutil;
 
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import seedu.address.model.game.Game;
 import seedu.address.model.person.Name;
@@ -51,6 +53,14 @@ public class PersonBuilder {
      */
     public PersonBuilder withTags(String... tags) {
         this.tags = SampleDataUtil.getTagSet(tags);
+        return this;
+    }
+
+    /**
+     * Parses the {@code games} into a {@code Set<Game>} and set it to the {@code Person} that we are building.
+     */
+    public PersonBuilder withGames(String... games) {
+        this.games = Arrays.stream(games).map(Game::new).collect(Collectors.toSet());
         return this;
     }
 


### PR DESCRIPTION
 ### Problem
  The `find` command only searched by contact name, requiring users to know a contact's real name. Users who only remember a friend's game or alias had no way to locate them without scrolling through the full list.

  ### Changes
  - Added `GameContainsKeywordPredicate` — filters contacts by game name (case-insensitive)
  - Added `AliasMatchesPredicate` — filters contacts by in-game alias (case-insensitive)
  - Updated `FindCommandParser` to detect `g/` and `al/` prefixes
  - Updated `FindCommand` to accept a general `Predicate<Person>`
  - Updated `MESSAGE_USAGE` to document new syntax
  - Added `withGames()` helper to `PersonBuilder` for tests    

  ### New Syntax
  | Command | Description |
  |---------|-------------|
  | `find KEYWORD [MORE_KEYWORDS]...` | Search by name (unchanged) |
  | `find g/GAME_NAME` | List all contacts who play the game | 
  | `find al/ALIAS` | Find the contact with that alias |       

  ### Files Changed
  **New:**
  - `GameContainsKeywordPredicate.java`
  - `AliasMatchesPredicate.java`
  - `GameContainsKeywordPredicateTest.java`
  - `AliasMatchesPredicateTest.java`

  **Modified:**
  - `FindCommand.java`
  - `FindCommandParser.java`
  - `FindCommandTest.java`
  - `FindCommandParserTest.java`
  - `PersonBuilder.java`

  ### Testing
  - [x] `find g/Valorant` returns all contacts with Valorant in
   their games list
  - [x] `find al/BenJumpin` returns the contact with alias     
  BenJumpin
  - [x] `find Alice Tan` still works as before
  - [x] Empty `g/` and `al/` prefixes show error message       
  - [x] All new predicates covered by unit tests
  
  CLOSES #67 