### PR TITLE
Fix stale ViewPanel after undo

### DIFF
--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -43,6 +43,11 @@ public class CommandResult {
     private final Person personToView;
 
     /**
+     * Whether the ViewPanel should be cleared.
+     */
+    private final boolean shouldClearView;
+
+    /**
      * Constructs a {@code CommandResult} with the specified fields.
      */
     public CommandResult(String feedbackToUser, boolean showHelp, boolean exit, Person personToView) {
@@ -53,6 +58,21 @@ public class CommandResult {
         this.pendingPerson = null;
         this.themeToSwitch = null;
         this.personToView = personToView;
+        this.shouldClearView = false;
+    }
+
+    /**
+     * Constructs a {@code CommandResult} that signals the ViewPanel should be cleared.
+     */
+    public CommandResult(String feedbackToUser, boolean shouldClearView) {
+        this.feedbackToUser = requireNonNull(feedbackToUser);
+        this.isShowHelp = false;
+        this.isExit = false;
+        this.isAwaitingConfirmation = false;
+        this.pendingPerson = null;
+        this.themeToSwitch = null;
+        this.personToView = null;
+        this.shouldClearView = shouldClearView;
     }
 
     /**
@@ -61,6 +81,8 @@ public class CommandResult {
     public CommandResult(String feedbackToUser, boolean showHelp, boolean exit) {
         this(feedbackToUser, showHelp, exit, null);
     }
+
+
 
     /**
      * Constructs a {@code CommandResult} for commands that require a theme switch.
@@ -73,6 +95,7 @@ public class CommandResult {
         this.pendingPerson = null;
         this.themeToSwitch = themeToSwitch;
         this.personToView = null;
+        this.shouldClearView = false;
     }
 
     /**
@@ -94,6 +117,7 @@ public class CommandResult {
         this.pendingPerson = requireNonNull(pendingPerson);
         this.themeToSwitch = null;
         this.personToView = null;
+        this.shouldClearView = false;
     }
 
     public String getFeedbackToUser() {
@@ -122,6 +146,10 @@ public class CommandResult {
 
     public Person getViewedPerson() {
         return personToView;
+    }
+
+    public boolean isClearView() {
+        return shouldClearView;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoCommand.java
@@ -29,6 +29,6 @@ public class UndoCommand extends Command {
             throw new CommandException(MESSAGE_NOTHING_TO_UNDO);
         }
         commandHistory.pop().undo(model);
-        return new CommandResult(MESSAGE_SUCCESS);
+        return new CommandResult(MESSAGE_SUCCESS, true);
     }
 }

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -187,7 +187,9 @@ public class MainWindow extends UiPart<Stage> {
             logger.info("Result: " + commandResult.getFeedbackToUser());
             resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
 
-            if (commandResult.getViewedPerson() != null) {
+            if (commandResult.isClearView()) {
+                viewPanel.clearPerson();
+            } else if (commandResult.getViewedPerson() != null) {
                 viewPanel.setPerson(commandResult.getViewedPerson());
             }
 

--- a/src/main/java/seedu/address/ui/ViewPanel.java
+++ b/src/main/java/seedu/address/ui/ViewPanel.java
@@ -36,6 +36,19 @@ public class ViewPanel extends UiPart<Region> {
     }
 
     /**
+     * Clears the ViewPanel and shows the placeholder text.
+     */
+    public void clearPerson() {
+        placeholderText.setVisible(true);
+        placeholderText.setManaged(true);
+        profileContainer.setVisible(false);
+        profileContainer.setManaged(false);
+        name.setText("");
+        tags.getChildren().clear();
+        gamesList.getChildren().clear();
+    }
+
+    /**
      * Updates the UI to display the details of the given {@code Person}.
      */
     public void setPerson(Person person) {


### PR DESCRIPTION
 ## Type of Change
  - [x] Bug Fix
  - [ ] New Feature
  - [ ] Enhancement / Refactor
  - [ ] Documentation
  - [ ] Tests

  ---

  ## Description
  After executing an undoable command (e.g. `alias add`, `game add`, `contact edit`),
  the ViewPanel would retain stale data even after `undo` reverted the underlying model changes.
  This fix adds a `shouldClearView` signal to `CommandResult` that `UndoCommand` uses to
  instruct `MainWindow` to clear the ViewPanel on undo.

  ---

  ## Related Issue
  Closes #117 

  ---

  ## Changes Made
  - `CommandResult.java` — added `shouldClearView` field, new constructor, and `isClearView()` getter
  - `UndoCommand.java` — returns `new CommandResult(MESSAGE_SUCCESS, true)` to signal ViewPanel clear
  - `ViewPanel.java` — added `clearPerson()` method that resets panel to placeholder state
  - `MainWindow.java` — checks `isClearView()` and calls `viewPanel.clearPerson()` on undo

  ---

  ## Screenshots / Demo
  N/A

  ---

  ## Testing Done
  - [x] Existing tests pass
  - [ ] New tests added
  - [x] Manually tested the following scenarios:
    1. `alias add` followed by `undo` — ViewPanel clears correctly
    2. `game add` followed by `undo` — ViewPanel clears correctly
    3. Normal commands (e.g. `alias add`, `game add`) still display the ViewPanel as expected

  ---

  ## Checklist
  - [x] Code follows the project's style guidelines
  - [x] Self-reviewed my own code
  - [x] No unnecessary files or debug code included
  - [ ] Relevant documentation updated (e.g. User Guide, Developer Guide)
  - [x] No breaking changes to existing functionality

  ---

  ## Additional Notes
  The fix is minimal — `shouldClearView` defaults to `false` in all existing constructors so
  no existing behaviour is affected. Only `UndoCommand` sets it to `true`.