### PR TITLE
Fix alias undo not resetting filtered list

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddAliasCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddAliasCommand.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ALIAS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_GAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.HashSet;
 import java.util.List;
@@ -139,6 +140,7 @@ public class AddAliasCommand extends Command implements UndoableCommand {
     @Override
     public void undo(Model model) {
         model.setPerson(personAfterEdit, personBeforeEdit);
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeleteAliasCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteAliasCommand.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ALIAS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_GAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.HashSet;
 import java.util.List;
@@ -135,6 +136,7 @@ public class DeleteAliasCommand extends Command implements UndoableCommand {
     @Override
     public void undo(Model model) {
         model.setPerson(personAfterEdit, personBeforeEdit);
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
     }
 
     @Override


### PR DESCRIPTION
 ## Type of Change
  - [x] Bug Fix                                                                                                                                       
  - [ ] New Feature                                                                                                                                     - [ ] Enhancement / Refactor                                                                                                                        
  - [ ] Documentation                                                                                                                                 
  - [ ] Tests                                                                                                                                                                                                                                                                                                 ---                                                                                                                                                 

  ## Description
  After running `alias add` or `alias delete` followed by `undo`, the contact list remained
  in a filtered state instead of resetting to show all contacts. This was inconsistent with
  `game add` and `game delete` which correctly reset the filter on undo.

  ---

  ## Related Issue
  Closes #118 

  ---

  ## Changes Made
  - `AddAliasCommand.java` — added `model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS)` to `undo()`
  - `DeleteAliasCommand.java` — added `model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS)` to `undo()`

  ---

  ## Screenshots / Demo
  N/A

  ---

  ## Testing Done
  - [x] Existing tests pass
  - [ ] New tests added
  - [x] Manually tested the following scenarios:
    1. `find Alice` → `alias add 1 g/Valorant al/Ace` → `undo` — full contact list is shown
    2. `find Alice` → `alias delete 1 g/Valorant al/Ace` → `undo` — full contact list is shown
    3. Normal `alias add` and `alias delete` without prior filter still work correctly

  ---

  ## Checklist
  - [x] Code follows the project's style guidelines
  - [x] Self-reviewed my own code
  - [x] No unnecessary files or debug code included
  - [ ] Relevant documentation updated (e.g. User Guide, Developer Guide)
  - [x] No breaking changes to existing functionality

  ---

  ## Additional Notes
  Fix mirrors the existing pattern in `AddGameCommand.undo()` (line 113-116) and
  `DeleteGameCommand.undo()` which already call `updateFilteredPersonList()` correctly.
