### PR TITLE
Update contact commands in user guide

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -381,7 +381,7 @@ Furthermore, certain edits can cause Harmony to behave in unexpected ways (e.g.,
 | **Undo**            | `undo` |
 | **Contact Add**     | `contact add n/NAME [t/TAG]…​ [g/GAME [al/ALIAS]…​]…​` <br> e.g., `contact add n/James Ho t/friend t/colleague` |
 | **Contact Delete**  | `contact delete INDEX` or `contact delete n/NAME`<br> e.g., `contact delete 1` or `contact delete n/James Ho` |
-| **Contact Edit**    | `contact edit n/NAME e/NEW_NAME`<br> e.g., `contact edit n/James Ho e/James Lee` |
+| **Contact Edit**    | `contact edit INDEX e/NEW_NAME` or `contact edit n/NAME e/NEW_NAME`<br> e.g., `contact edit 1 e/James Lee` or `contact edit n/James Ho e/James Lee` |
 | **Clear**           | `clear` |
 | **Alias Add**       | `alias add INDEX g/GAME_NAME al/ALIAS` or `alias add n/CONTACT_NAME g/GAME_NAME al/ALIAS`<br> e.g., `alias add 1 g/Valorant al/Benjumpin` |
 | **Alias Delete**    | `alias delete INDEX g/GAME_NAME al/ALIAS` or `alias delete n/CONTACT_NAME g/GAME_NAME al/ALIAS`<br> e.g., `alias delete 1 g/Valorant al/Benjumpin` |


### PR DESCRIPTION
## Type of Change
- [ ] Bug Fix
- [ ] New Feature
- [ ] Enhancement / Refactor
- [x] Documentation
- [ ] Tests

---

## Description
The User Guide for `contact delete` only documented name-based deletion
(`contact delete n/NAME`), omitting the index-based format (`contact delete INDEX`)
that the command already supports. The command summary table was also outdated.
This PR updates both to be consistent with the actual command behaviour and
with other commands in the UG.

---

## Related Issue
Closes #128 

---

## Changes Made
- Updated `contact delete` section to show both `INDEX` and `n/NAME` formats
- Added index-based example (`contact delete 1`) to the section
- Added note that `0` targets the user profile
- Updated command summary table for `contact delete` and `contact edit` to
  show both formats

---

## Screenshots / Demo
N/A — documentation only

---

## Testing Done
- [ ] Existing tests pass
- [ ] New tests added
- [x] Manually tested the following scenarios:
  1. Verified `contact delete 1` works as documented
  2. Verified `contact delete n/NAME` still works as documented

---

## Checklist
- [x] Code follows the project's style guidelines
- [x] Self-reviewed my own code
- [x] No unnecessary files or debug code included
- [x] Relevant documentation updated (e.g. User Guide, Developer Guide)
- [x] No breaking changes to existing functionality

---

## Additional Notes
No code changes — documentation only. The underlying command already supported
index-based deletion; the UG simply did not reflect it.
