### PR TITLE
Add UML diagrams for delete confirmation feature

### DIFF
--- a/docs/diagrams/DeleteCommandClassDiagram.puml
+++ b/docs/diagrams/DeleteCommandClassDiagram.puml
@@ -8,41 +8,11 @@ package Logic {
 
 Class "{abstract}\nCommand" as Command
 Class "<<interface>>\nUndoableCommand" as UndoableCommand
+Class LogicManager
+Class DeleteContactCommand
+Class DeleteGameCommand
+Class DeleteAliasCommand
 
-Class LogicManager {
-    - pendingDeletePerson : Person
-    - pendingDeleteCommand : DeleteContactCommand
-    - commandHistory : Deque<UndoableCommand>
-    + execute(commandText) : CommandResult
-    - handleDeleteConfirmation(input) : CommandResult
-}
-
-Class DeleteContactCommand {
-    + execute(model) : CommandResult
-    + setDeletedPerson(person)
-    + undo(model)
-}
-
-Class DeleteGameCommand {
-    + execute(model) : CommandResult
-    + undo(model)
-}
-
-Class DeleteAliasCommand {
-    + execute(model) : CommandResult
-    + undo(model)
-}
-
-Class CommandResult {
-    - feedbackToUser : String
-    - isAwaitingConfirmation : boolean
-    - pendingPerson : Person
-}
-
-}
-
-package Model {
-Class HiddenModel #FFFFFF
 }
 
 DeleteContactCommand -up-|> Command
@@ -53,21 +23,12 @@ DeleteContactCommand .up.|> UndoableCommand
 DeleteGameCommand .up.|> UndoableCommand
 DeleteAliasCommand .up.|> UndoableCommand
 
-Command .right.> CommandResult : <<create>>
-
-LogicManager --> DeleteContactCommand : stores pending
 LogicManager .right.> Command : <<call>>
-LogicManager --> HiddenModel
+LogicManager --> DeleteContactCommand : stores for confirmation
 
-note bottom of DeleteContactCommand
-  execute() returns confirmation prompt.
-  Actual deletion happens in
-  LogicManager.handleDeleteConfirmation()
-  after user types "y".
-end note
-
-note bottom of DeleteGameCommand
-  execute() deletes immediately\n(no confirmation)
+note right of DeleteContactCommand
+  execute() returns a confirmation prompt.
+  Deletion only occurs after user types "y".
 end note
 
 @enduml

--- a/docs/diagrams/DeleteConfirmSequenceDiagram.puml
+++ b/docs/diagrams/DeleteConfirmSequenceDiagram.puml
@@ -4,7 +4,6 @@ skinparam ArrowFontStyle plain
 
 box Logic LOGIC_COLOR_T1
 participant ":LogicManager" as LogicManager LOGIC_COLOR
-participant ":AddressBookParser" as AddressBookParser LOGIC_COLOR
 participant "d:DeleteContactCommand" as DeleteCommand LOGIC_COLOR
 end box
 
@@ -12,19 +11,10 @@ box Model MODEL_COLOR_T1
 participant "m:Model" as Model MODEL_COLOR
 end box
 
-box Storage STORAGE_COLOR_T1
-participant "s:Storage" as Storage STORAGE_COLOR
-end box
-
 == Step 1: User issues delete command ==
 
 [-> LogicManager : execute("contact delete n/Alice")
 activate LogicManager
-
-LogicManager -> AddressBookParser : parseCommand(...)
-activate AddressBookParser
-AddressBookParser --> LogicManager : d
-deactivate AddressBookParser
 
 LogicManager -> DeleteCommand : execute(m)
 activate DeleteCommand
@@ -32,9 +22,9 @@ note right : Finds person,\ndoes NOT delete yet
 DeleteCommand --> LogicManager : CommandResult\n(isAwaitingConfirmation=true)
 deactivate DeleteCommand
 
-note over LogicManager : Stores pendingDeletePerson\nand pendingDeleteCommand
+note over LogicManager : Stores pending person and command,\nshows confirmation prompt to user
 
-[<-- LogicManager : confirmation prompt
+[<-- LogicManager : "Are you sure? (y/n)"
 deactivate LogicManager
 
 == Step 2: User confirms ==
@@ -42,24 +32,12 @@ deactivate LogicManager
 [-> LogicManager : execute("y")
 activate LogicManager
 
-note over LogicManager : pendingDeletePerson != null,\nroutes to handleDeleteConfirmation()
-
-LogicManager -> Model : deletePerson(person)
+LogicManager -> Model : delete person
 activate Model
 Model --> LogicManager
 deactivate Model
 
-LogicManager -> DeleteCommand : setDeletedPerson(person)
-activate DeleteCommand
-DeleteCommand --> LogicManager
-deactivate DeleteCommand
-
 note over LogicManager : Pushes command to\ncommandHistory for undo
-
-LogicManager -> Storage : saveAddressBook(...)
-activate Storage
-Storage --> LogicManager
-deactivate Storage
 
 [<-- LogicManager : "Contact deleted: Alice"
 deactivate LogicManager


### PR DESCRIPTION
## Type of Change
- [ ] Bug Fix
- [ ] New Feature
- [ ] Enhancement / Refactor
- [x] Documentation
- [ ] Tests

---

## Description
Adds two UML diagrams documenting the delete confirmation feature
for the Developer Guide. The diagrams will be incorporated into
the DG text in a follow-up PR after pending DG changes are merged.

---

## Related Issue
Closes #138 

---

## Changes Made
- Added `DeleteConfirmSequenceDiagram.puml` — sequence diagram
  showing the two-step flow: user issues delete command, receives
  confirmation prompt, then confirms with `y` to trigger deletion
- Added `DeleteCommandClassDiagram.puml` — class diagram showing
  `DeleteContactCommand`, `DeleteGameCommand`, `DeleteAliasCommand`
  extending `Command` and implementing `UndoableCommand`, and
  `LogicManager`'s role in the confirmation flow

---

## Screenshots / Demo
### Class Diagram (DeleteCommandClassDiagram.puml)
- Shows the structure of the three delete commands. 
- All three extend Command and implement UndoableCommand. 
- LogicManager holds a reference to DeleteContactCommand specifically during the confirmation window, since only contact delete uses the two-step confirmation flow.
<img width="860" height="222" alt="image" src="https://github.com/user-attachments/assets/c78f1fd0-ae0c-407b-a3f1-0be2c1c0202f" />

### Sequence Diagram (DeleteConfirmSequenceDiagram.puml)
- Shows the two-step flow for contact delete. 
- Step 1: DeleteContactCommand#execute() finds the target person but defers deletion, returning a confirmation prompt.
- Step 2: when the user confirms with y, LogicManager performs the deletion and pushes the command to undo history.
<img width="623" height="537" alt="image" src="https://github.com/user-attachments/assets/883c1a97-7599-4a4a-8dc2-61c3ab27cf6d" />

Diagrams will be rendered when incorporated into the DG

---

## Testing Done
- [x] Existing tests pass
- [ ] New tests added

---

## Checklist
- [x] Code follows the project's style guidelines
- [x] Self-reviewed my own code
- [x] No unnecessary files or debug code included
- [ ] Relevant documentation updated (e.g. User Guide, Developer Guide)
- [x] No breaking changes to existing functionality

---

## Additional Notes
DG text referencing these diagrams will be added in a follow-up PR
once the currently open DG PR is merged.
