### PR TITLE
Add 'me' parameter to MESSAGE_USAGE for commands supporting user profile

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddAliasCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddAliasCommand.java
@@ -29,15 +29,19 @@ public class AddAliasCommand extends Command implements UndoableCommand {
     public static final String COMMAND_WORD = "alias add";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Adds an alias to a game of a contact using either their index OR their full name.\n"
+            + ": Adds an alias to a game of a contact using either their index, full name,"
+            + " or 'me' for your own profile.\n"
             + "Parameters (by Index): INDEX (must be a positive integer) "
             + PREFIX_GAME + "GAME " + PREFIX_ALIAS + "ALIAS\n"
             + "Parameters (by Name): "
             + PREFIX_NAME + "CONTACT_NAME " + PREFIX_GAME + "GAME " + PREFIX_ALIAS + "ALIAS\n"
+            + "Parameters (User Profile): me " + PREFIX_GAME + "GAME " + PREFIX_ALIAS + "ALIAS\n"
             + "Example 1: "
             + COMMAND_WORD + " 1 " + PREFIX_GAME + "Valorant " + PREFIX_ALIAS + "Benjumpin\n"
             + "Example 2: "
-            + COMMAND_WORD + " " + PREFIX_NAME + "Benjamin " + PREFIX_GAME + "Valorant " + PREFIX_ALIAS + "Benjumpin";
+            + COMMAND_WORD + " " + PREFIX_NAME + "Benjamin " + PREFIX_GAME + "Valorant " + PREFIX_ALIAS + "Benjumpin\n"
+            + "Example 3: "
+            + COMMAND_WORD + " me " + PREFIX_GAME + "Valorant " + PREFIX_ALIAS + "Benjumpin";
 
     public static final String MESSAGE_SUCCESS = "Alias '%3$s' added to %1$s's game: %2$s";
     public static final String MESSAGE_PERSON_NOT_FOUND = "Error: Contact does not exist.";

--- a/src/main/java/seedu/address/logic/commands/AddGameCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddGameCommand.java
@@ -24,13 +24,14 @@ public class AddGameCommand extends Command implements UndoableCommand {
 
     public static final String COMMAND_WORD = "add";
 
-    // 1. Updated MESSAGE_USAGE to show both Index and Name options
     public static final String MESSAGE_USAGE = "game " + COMMAND_WORD
-            + ": Adds a game to a contact using either their index OR their full name.\n"
+            + ": Adds a game to a contact using either their index, full name, or 'me' for your own profile.\n"
             + "Parameters (by Index): INDEX (must be a positive integer) " + PREFIX_GAME + "GAME_NAME\n"
             + "Parameters (by Name): " + PREFIX_NAME + "CONTACT_NAME " + PREFIX_GAME + "GAME_NAME\n"
+            + "Parameters (User Profile): me " + PREFIX_GAME + "GAME_NAME\n"
             + "Example 1: game " + COMMAND_WORD + " 1 " + PREFIX_GAME + "Minecraft\n"
-            + "Example 2: game " + COMMAND_WORD + " " + PREFIX_NAME + "Zi Xuan " + PREFIX_GAME + "Minecraft";
+            + "Example 2: game " + COMMAND_WORD + " " + PREFIX_NAME + "Zi Xuan " + PREFIX_GAME + "Minecraft\n"
+            + "Example 3: game " + COMMAND_WORD + " me " + PREFIX_GAME + "Minecraft";
 
     public static final String MESSAGE_SUCCESS = "Game %1$s added to %2$s";
     public static final String MESSAGE_CONTACT_NOT_FOUND = "Error: Contact does not exist.";

--- a/src/main/java/seedu/address/logic/commands/DeleteAliasCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteAliasCommand.java
@@ -29,15 +29,18 @@ public class DeleteAliasCommand extends Command implements ConfirmableDeleteComm
     public static final String COMMAND_WORD = "alias delete";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Deletes an alias from a game of a contact using either their index OR their full name.\n"
+            + ": Deletes an alias from a game of a contact using either their index, full name,"
+            + " or 'me' for your own profile.\n"
             + "Parameters (by Index): INDEX (must be a positive integer) "
             + PREFIX_GAME + "GAME " + PREFIX_ALIAS + "ALIAS\n"
             + "Parameters (by Name): "
             + PREFIX_NAME + "CONTACT_NAME " + PREFIX_GAME + "GAME " + PREFIX_ALIAS + "ALIAS\n"
+            + "Parameters (User Profile): me " + PREFIX_GAME + "GAME " + PREFIX_ALIAS + "ALIAS\n"
             + "Example 1: " + COMMAND_WORD + " 1 " + PREFIX_GAME + "Valorant "
             + PREFIX_ALIAS + "Benjumpin\n"
             + "Example 2: " + COMMAND_WORD + " " + PREFIX_NAME + "Benjamin "
-            + PREFIX_GAME + "Valorant " + PREFIX_ALIAS + "Benjumpin";
+            + PREFIX_GAME + "Valorant " + PREFIX_ALIAS + "Benjumpin\n"
+            + "Example 3: " + COMMAND_WORD + " me " + PREFIX_GAME + "Valorant " + PREFIX_ALIAS + "Benjumpin";
 
     public static final String MESSAGE_SUCCESS = "Alias \"%3$s\" removed from %1$s in %2$s";
     public static final String MESSAGE_PERSON_NOT_FOUND = "Error: Name does not exist";

--- a/src/main/java/seedu/address/logic/commands/DeleteContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteContactCommand.java
@@ -21,11 +21,13 @@ public class DeleteContactCommand extends Command implements ConfirmableDeleteCo
     public static final String COMMAND_WORD = "contact delete";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Deletes the contact identified by index or name.\n"
+            + ": Deletes the contact identified by index, name, or 'me' for your own profile.\n"
             + "Parameters (by Index): INDEX (must be a positive integer)\n"
             + "Parameters (by Name): " + PREFIX_NAME + "NAME\n"
+            + "Parameters (User Profile): me\n"
             + "Example 1: " + COMMAND_WORD + " 1\n"
-            + "Example 2: " + COMMAND_WORD + " " + PREFIX_NAME + "bob";
+            + "Example 2: " + COMMAND_WORD + " " + PREFIX_NAME + "bob\n"
+            + "Example 3: " + COMMAND_WORD + " me";
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Contact deleted: %1$s";
     public static final String MESSAGE_PERSON_NOT_FOUND = "Error: Name not found";

--- a/src/main/java/seedu/address/logic/commands/DeleteGameCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteGameCommand.java
@@ -24,11 +24,13 @@ public class DeleteGameCommand extends Command implements ConfirmableDeleteComma
 
     public static final String COMMAND_WORD = "delete";
     public static final String MESSAGE_USAGE = "game " + COMMAND_WORD
-            + ": Deletes a game from a contact using either their index OR their full name.\n"
+            + ": Deletes a game from a contact using either their index, full name, or 'me' for your own profile.\n"
             + "Parameters (by Index): INDEX (must be a positive integer) " + PREFIX_GAME + "GAME_NAME\n"
             + "Parameters (by Name): " + PREFIX_NAME + "CONTACT_NAME " + PREFIX_GAME + "GAME_NAME\n"
+            + "Parameters (User Profile): me " + PREFIX_GAME + "GAME_NAME\n"
             + "Example 1: game " + COMMAND_WORD + " 1 " + PREFIX_GAME + "Minecraft\n"
-            + "Example 2: game " + COMMAND_WORD + " " + PREFIX_NAME + "Zi Xuan " + PREFIX_GAME + "Minecraft";
+            + "Example 2: game " + COMMAND_WORD + " " + PREFIX_NAME + "Zi Xuan " + PREFIX_GAME + "Minecraft\n"
+            + "Example 3: game " + COMMAND_WORD + " me " + PREFIX_GAME + "Minecraft";
 
     public static final String MESSAGE_SUCCESS = "Game \"%1$s\" removed from %2$s";
     public static final String MESSAGE_CONTACT_NOT_FOUND = "Error: Contact does not exist.";

--- a/src/main/java/seedu/address/logic/commands/EditAliasCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditAliasCommand.java
@@ -29,16 +29,21 @@ public class EditAliasCommand extends Command implements UndoableCommand {
     public static final String COMMAND_WORD = "alias edit";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Edits an alias of a game of a contact using either their index OR their full name.\n"
+            + ": Edits an alias of a game of a contact using either their index, full name,"
+            + " or 'me' for your own profile.\n"
             + "Parameters (by Index): INDEX (must be a positive integer) "
             + PREFIX_GAME + "GAME " + PREFIX_ALIAS + "OLD_ALIAS " + PREFIX_NEW_ALIAS + "NEW_ALIAS\n"
             + "Parameters (by Name): "
             + PREFIX_NAME + "CONTACT_NAME " + PREFIX_GAME + "GAME " + PREFIX_ALIAS + "OLD_ALIAS "
             + PREFIX_NEW_ALIAS + "NEW_ALIAS\n"
+            + "Parameters (User Profile): me " + PREFIX_GAME + "GAME " + PREFIX_ALIAS + "OLD_ALIAS "
+            + PREFIX_NEW_ALIAS + "NEW_ALIAS\n"
             + "Example 1: " + COMMAND_WORD + " 1 " + PREFIX_GAME + "Valorant "
             + PREFIX_ALIAS + "JohnnyV " + PREFIX_NEW_ALIAS + "JohnnyValorant\n"
             + "Example 2: " + COMMAND_WORD + " " + PREFIX_NAME + "John "
-            + PREFIX_GAME + "Valorant " + PREFIX_ALIAS + "JohnnyV " + PREFIX_NEW_ALIAS + "JohnnyValorant";
+            + PREFIX_GAME + "Valorant " + PREFIX_ALIAS + "JohnnyV " + PREFIX_NEW_ALIAS + "JohnnyValorant\n"
+            + "Example 3: " + COMMAND_WORD + " me " + PREFIX_GAME + "Valorant "
+            + PREFIX_ALIAS + "JohnnyV " + PREFIX_NEW_ALIAS + "JohnnyValorant";
 
     public static final String MESSAGE_SUCCESS = "Alias \"%3$s\" updated to \"%4$s\" for %1$s in %2$s";
     public static final String MESSAGE_PERSON_NOT_FOUND = "Error: Name not found";

--- a/src/main/java/seedu/address/logic/commands/EditContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditContactCommand.java
@@ -22,11 +22,13 @@ public class EditContactCommand extends Command implements UndoableCommand {
     public static final String COMMAND_WORD = "contact edit";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Edits the name of a contact identified by index or current name.\n"
+            + ": Edits the name of a contact identified by index, name, or 'me' for your own profile.\n"
             + "Parameters (by Index): INDEX (must be a positive integer) " + PREFIX_NEW_NAME + "NEW_NAME\n"
             + "Parameters (by Name): " + PREFIX_NAME + "NAME " + PREFIX_NEW_NAME + "NEW_NAME\n"
+            + "Parameters (User Profile): me " + PREFIX_NEW_NAME + "NEW_NAME\n"
             + "Example 1: " + COMMAND_WORD + " 1 " + PREFIX_NEW_NAME + "Jan\n"
-            + "Example 2: " + COMMAND_WORD + " " + PREFIX_NAME + "Janelle " + PREFIX_NEW_NAME + "Jan";
+            + "Example 2: " + COMMAND_WORD + " " + PREFIX_NAME + "Janelle " + PREFIX_NEW_NAME + "Jan\n"
+            + "Example 3: " + COMMAND_WORD + " me " + PREFIX_NEW_NAME + "Jan";
 
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Contact updated: %1$s \u2192 %2$s";
     public static final String MESSAGE_PERSON_NOT_FOUND = "Error: Name not found";

--- a/src/main/java/seedu/address/logic/commands/ListGameCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListGameCommand.java
@@ -21,11 +21,13 @@ public class ListGameCommand extends Command {
     public static final String COMMAND_WORD = "list";
 
     public static final String MESSAGE_USAGE = "game " + COMMAND_WORD
-            + ": Lists all games of a contact using either their index OR their full name.\n"
+            + ": Lists all games of a contact using either their index, full name, or 'me' for your own profile.\n"
             + "Parameters (by Index): INDEX (must be a positive integer)\n"
             + "Parameters (by Name): " + PREFIX_NAME + "CONTACT_NAME\n"
+            + "Parameters (User Profile): me\n"
             + "Example 1: game " + COMMAND_WORD + " 1\n"
-            + "Example 2: game " + COMMAND_WORD + " " + PREFIX_NAME + "Zi Xuan";
+            + "Example 2: game " + COMMAND_WORD + " " + PREFIX_NAME + "Zi Xuan\n"
+            + "Example 3: game " + COMMAND_WORD + " me";
 
     public static final String MESSAGE_SUCCESS = "%1$s's games: %2$s";
     public static final String MESSAGE_NO_GAMES = "%1$s currently has no games.";


### PR DESCRIPTION
                              
                                                                                                                            
  ## Type of Change                                                                                                         
  - [x] Bug Fix                                                                                                                                                                                                                                         
  ---                                                                                                                       
                  
  ## Description
  Several commands supported `me` as input to target the user's own profile (e.g. `game add me g/Minecraft`), but none of   
  them documented this in their usage messages. Users had no way to discover this feature from error messages or help text. 

  ---

  ## Related Issue
  Closes #166 

  ---

  ## Changes Made
  - Added `Parameters (User Profile): me` line to `MESSAGE_USAGE` in 8 commands
  - Added a corresponding `Example 3` using `me` to each affected command
  - Affected commands: `contact delete`, `contact edit`, `game add`, `game delete`, `game list`, `alias add`, `alias        
  delete`, `alias edit`

  ---

  ## Testing Done
  - [x] Existing tests pass
  - [ ] New tests added
  - [x] Manually tested the following scenarios:
    1. Type `game add` — usage message now shows `Parameters (User Profile): me g/GAME_NAME`
    2. Run `game add me g/Minecraft` — successfully adds game to own profile
    3. Run `game list me` — lists games on own profile
    4. Run `alias add me g/Minecraft al/MyAlias` — adds alias to own profile
    5. Run `contact edit me nn/NewName` — edits own profile name

  ---

  ## Checklist
  - [x] Code follows the project's style guidelines
  - [x] Self-reviewed my own code
  - [x] No unnecessary files or debug code included
  - [ ] Relevant documentation updated (e.g. User Guide, Developer Guide)
  - [x] No breaking changes to existing functionality

  ---

  ## Additional Notes
  `contact view` and `copy` already correctly documented `me` and required no changes.