### PR TITLE
Add the ability to press esc key to close help window

### DIFF
--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -39,7 +39,7 @@ public class HelpWindow extends UiPart<Stage> {
 
         root.getScene().setOnKeyPressed(event -> {
             if (event.getCode() == KeyCode.ESCAPE) {
-                hide(); 
+                hide();
             }
         });
     }


### PR DESCRIPTION
## Type of Change
- [ ] Bug Fix
- [ ] New Feature
- [x] Enhancement / Refactor
- [ ] Documentation
- [ ] Tests

---

## Description
This PR enhances the Quality of Life (QoL) for keyboard-heavy users by allowing the Help Window to be dismissed using the `Escape` (`Esc`) key, removing the need to use the mouse to close the window.

---

## Related Issue
Closes #171 
---

## Changes Made
- **`HelpWindow.java`**: 
  - Imported `javafx.scene.input.KeyCode`.
  - Added a `setOnKeyPressed` event listener to the root stage's scene inside the main constructor. 
  - Configured the listener to trigger the existing `hide()` method whenever the `ESCAPE` key is detected while the window is in focus.

---

## Screenshots / Demo
N/A - Minor behavioral UI change.

---

## Testing Done
- [x] Existing tests pass 
- [ ] New tests added
- [x] Manually tested the following scenarios:
  1. Opened the Help Window via the `help` CLI command and pressed `Esc`. Verified the window closed successfully.
  2. Opened the Help Window via the `F1` hotkey, clicked inside the window to ensure focus, and pressed `Esc`. Verified the window closed successfully.
  3. Verified the standard "Close" button still functions as expected.

---

## Checklist
- [x] Code follows the project's style guidelines
- [x] Self-reviewed my own code
- [x] No unnecessary files or debug code included
- [ ] Relevant documentation updated (e.g. User Guide, Developer Guide)
- [x] No breaking changes to existing functionality

---

## Additional Notes
By attaching the listener directly to the `Scene` rather than a specific node, the `Esc` key will successfully close the window regardless of where the user last clicked inside it.