### PR TITLE
Fix `contact delete me` breaking the application due to missing UserProfile

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteContactCommand.java
@@ -102,7 +102,11 @@ public class DeleteContactCommand extends Command implements ConfirmableDeleteCo
 
     @Override
     public void undo(Model model) {
-        model.addPerson(personToDelete);
+        if (useUserProfile) {
+            model.setPerson(PLACEHOLDER_PROFILE, personToDelete);
+        } else {
+            model.addPerson(personToDelete);
+        }
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeleteContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteContactCommand.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.model.util.GeneratePlaceholder.PLACEHOLDER_PROFILE;
 
 import java.util.List;
 
@@ -35,6 +36,9 @@ public class DeleteContactCommand extends Command implements ConfirmableDeleteCo
     public static final String MESSAGE_DELETE_CONFIRMATION =
             "%1$s\nAre you sure you want to delete %2$s? (y/n)";
     public static final String MESSAGE_DELETE_CANCELLED = "Deletion of %1$s cancelled.";
+    public static final String MESSAGE_DELETE_USERPROFILE = "Your User Profile has been successfully reset to default.";
+    public static final String MESSAGE_DELETE_USERPROFILE_CONFIRMATION =
+            "Are you sure you want to reset User Profile? (y/n)";
 
     private final Index targetIndex;
     private final Name targetName;
@@ -80,7 +84,8 @@ public class DeleteContactCommand extends Command implements ConfirmableDeleteCo
         this.personToDelete = personToDelete;
         String confirmationMessage = String.format(MESSAGE_DELETE_CONFIRMATION,
                 Messages.format(personToDelete), personToDelete.getName());
-        return new CommandResult(confirmationMessage, personToDelete);
+        return new CommandResult(useUserProfile ? MESSAGE_DELETE_USERPROFILE_CONFIRMATION : confirmationMessage,
+                personToDelete);
     }
 
     @Override
@@ -91,7 +96,8 @@ public class DeleteContactCommand extends Command implements ConfirmableDeleteCo
     @Override
     public CommandResult performDeletion(Model model) {
         model.deletePerson(personToDelete);
-        return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, personToDelete.getName()));
+        return new CommandResult(useUserProfile ? MESSAGE_DELETE_USERPROFILE
+                : String.format(MESSAGE_DELETE_PERSON_SUCCESS, personToDelete.getName()));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -1,13 +1,12 @@
 package seedu.address.model;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.model.util.GeneratePlaceholder.PLACEHOLDER_PROFILE;
 
-import java.util.HashSet;
 import java.util.List;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.util.ToStringBuilder;
-import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.UniquePersonList;
 
@@ -83,7 +82,7 @@ public class AddressBook implements ReadOnlyAddressBook {
      * The UserProfile must not already exist in the address book.
      */
     public void addUserProfile() {
-        persons.addFirst(new Person(new Name("PLACEHOLDER"), new HashSet<>(), true));
+        persons.addFirst(PLACEHOLDER_PROFILE);
     }
 
     /**

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -100,19 +100,15 @@ public class ModelManager implements Model {
     @Override
     public void deletePerson(Person target) {
         addressBook.removePerson(target);
+        if (target.isUserProfile()) {
+            addUserProfile();
+        }
     }
 
     @Override
     public void addPerson(Person person) {
         addressBook.addPerson(person);
         updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-    }
-
-    @Override
-    public void addUserProfile() {
-        if (getUserProfile().isEmpty()) {
-            addressBook.addUserProfile();
-        }
     }
 
     @Override
@@ -129,6 +125,13 @@ public class ModelManager implements Model {
         return addressBook.getPersonList().stream()
                 .filter(Person::isUserProfile)
                 .findFirst();
+    }
+
+    @Override
+    public void addUserProfile() {
+        if (getUserProfile().isEmpty()) {
+            addressBook.addUserProfile();
+        }
     }
 
     //=========== Filtered Person List Accessors =============================================================

--- a/src/main/java/seedu/address/model/util/GeneratePlaceholder.java
+++ b/src/main/java/seedu/address/model/util/GeneratePlaceholder.java
@@ -11,9 +11,18 @@ import seedu.address.model.person.Person;
  * Contains utility methods for populating {@code AddressBook} with sample data.
  */
 public class GeneratePlaceholder {
+    /**
+     * The single, static placeholder instance used whenever the User Profile is missing.
+     */
+    public static final Person PLACEHOLDER_PROFILE = new Person(
+            new Name("PLACEHOLDER"),
+            new HashSet<>(),
+            true
+    );
+
     public static ReadOnlyAddressBook getPlaceHolderddressBook() {
         AddressBook placeHolderAb = new AddressBook();
-        placeHolderAb.addPerson(new Person(new Name("PLACEHOLDER"), new HashSet<>(), true));
+        placeHolderAb.addPerson(PLACEHOLDER_PROFILE);
         return placeHolderAb;
     }
 

--- a/src/test/java/seedu/address/logic/commands/AddAliasCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddAliasCommandTest.java
@@ -215,17 +215,6 @@ public class AddAliasCommandTest {
     }
 
     @Test
-    public void execute_noProfile_failure() {
-        Model emptyModel = new ModelManager(new AddressBook(), new UserPrefs());
-        Game game = new Game("Valorant");
-        Alias alias = new Alias("JohnV");
-        emptyModel.deletePerson(emptyModel.getFilteredPersonList().get(0));
-
-        AddAliasCommand addAliasCommand = new AddAliasCommand(null, null, game, alias, true);
-        assertCommandFailure(addAliasCommand, emptyModel, "No user profile found.");
-    }
-
-    @Test
     public void execute_nullIndexAndName_failure() {
         Game game = new Game("Valorant");
         Alias alias = new Alias("SomeAlias");

--- a/src/test/java/seedu/address/logic/commands/AddGameCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddGameCommandTest.java
@@ -161,15 +161,6 @@ public class AddGameCommandTest {
     }
 
     @Test
-    public void execute_noProfile_failure() {
-        Model emptyModel = new ModelManager(new AddressBook(), new UserPrefs());
-        emptyModel.deletePerson(emptyModel.getFilteredPersonList().get(0));
-        Game gameToAdd = new Game("Minecraft");
-        AddGameCommand addGameCommand = new AddGameCommand(null, null, gameToAdd, true);
-        assertCommandFailure(addGameCommand, emptyModel, "No user profile found.");
-    }
-
-    @Test
     public void execute_nullIndexAndName_failure() {
         Game gameToAdd = new Game("Minecraft");
         AddGameCommand addGameCommand = new AddGameCommand(null, null, gameToAdd, false);

--- a/src/test/java/seedu/address/logic/commands/DeleteAliasCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteAliasCommandTest.java
@@ -173,17 +173,6 @@ public class DeleteAliasCommandTest {
     }
 
     @Test
-    public void execute_noProfile_failure() {
-        Model emptyModel = new ModelManager(new AddressBook(), new UserPrefs());
-        Game game = new Game("Valorant");
-        Alias alias = new Alias("JohnV");
-        emptyModel.deletePerson(emptyModel.getFilteredPersonList().get(0));
-
-        DeleteAliasCommand deleteAliasCommand = new DeleteAliasCommand(null, null, game, alias, true);
-        assertCommandFailure(deleteAliasCommand, emptyModel, "No user profile found.");
-    }
-
-    @Test
     public void getCancelMessage_returnsCorrectMessage() throws Exception {
         Person firstPerson = model.getFilteredPersonList().get(0);
         Game game = new Game("Valorant");

--- a/src/test/java/seedu/address/logic/commands/DeleteContactCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteContactCommandTest.java
@@ -235,16 +235,19 @@ public class DeleteContactCommandTest {
     public void performDeletion_deleteUserProfile_success() throws Exception {
         // Setup a custom model with a User Profile
         Model customModel = new ModelManager(new AddressBook(), new UserPrefs());
-        Person userProfile = new Person(new Name("My Profile"), new java.util.HashSet<>(), true);
-        customModel.addPerson(userProfile);
+        Person userProfile = new Person(new Name("ALICE"), new java.util.HashSet<>(), true);
+        customModel.setPerson(PLACEHOLDER_PROFILE, userProfile);
 
         // Create a command targeting the user profile (3rd boolean parameter = true)
         DeleteContactCommand deleteCommand = new DeleteContactCommand(null, null, true);
 
         // Execute the actual deletion
-        CommandResult result = deleteCommand.performDeletion(customModel);
+        CommandResult result = deleteCommand.execute(customModel);
 
-        // Verify the custom success message is returned
+        assertEquals("Are you sure you want to reset User Profile? (y/n)", result.getFeedbackToUser());
+
+        result = deleteCommand.performDeletion(customModel);
+
         assertEquals("Your User Profile has been successfully reset to default.", result.getFeedbackToUser());
 
         // Verify the original profile is no longer in the list (replaced by placeholder)

--- a/src/test/java/seedu/address/logic/commands/DeleteContactCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteContactCommandTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.model.util.GeneratePlaceholder.PLACEHOLDER_PROFILE;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.ALICE;
@@ -161,15 +162,6 @@ public class DeleteContactCommandTest {
     }
 
     @Test
-    public void execute_noUserProfile_throwsCommandException() {
-        Model emptyModel = new ModelManager(new AddressBook(), new UserPrefs());
-        DeleteContactCommand deleteCommand = new DeleteContactCommand(null, null, true);
-        emptyModel.deletePerson(emptyModel.getFilteredPersonList().get(0));
-
-        assertCommandFailure(deleteCommand, emptyModel, "No user profile found.");
-    }
-
-    @Test
     public void execute_nullIndexAndName_throwsCommandException() {
         DeleteContactCommand deleteCommand = new DeleteContactCommand(null, null, false);
         assertCommandFailure(deleteCommand, model, DeleteContactCommand.MESSAGE_PERSON_NOT_FOUND);
@@ -237,6 +229,66 @@ public class DeleteContactCommandTest {
         deleteCommand.undo(model);
 
         assertTrue(model.getFilteredPersonList().contains(personToDelete));
+    }
+
+    @Test
+    public void performDeletion_deleteUserProfile_success() throws Exception {
+        // Setup a custom model with a User Profile
+        Model customModel = new ModelManager(new AddressBook(), new UserPrefs());
+        Person userProfile = new Person(new Name("My Profile"), new java.util.HashSet<>(), true);
+        customModel.addPerson(userProfile);
+
+        // Create a command targeting the user profile (3rd boolean parameter = true)
+        DeleteContactCommand deleteCommand = new DeleteContactCommand(null, null, true);
+
+        // Execute the actual deletion
+        CommandResult result = deleteCommand.performDeletion(customModel);
+
+        // Verify the custom success message is returned
+        assertEquals("Your User Profile has been successfully reset to default.", result.getFeedbackToUser());
+
+        // Verify the original profile is no longer in the list (replaced by placeholder)
+        assertFalse(customModel.getFilteredPersonList().contains(userProfile));
+    }
+
+    @Test
+    public void undo_deleteUserProfile_restoresOriginalProfile() throws Exception {
+        // Setup a custom model with a User Profile
+        Model customModel = new ModelManager(new AddressBook(), new UserPrefs());
+        Person userProfile = new Person(new Name("ALICE"), new java.util.HashSet<>(), true);
+        customModel.setPerson(PLACEHOLDER_PROFILE, userProfile);
+        DeleteContactCommand deleteCommand = new DeleteContactCommand(null, null, true);
+
+        // Execute the command to trigger the deletion and self-healing
+        deleteCommand.execute(customModel);
+        deleteCommand.performDeletion(customModel);
+
+        // Verify the original profile is gone
+        assertFalse(customModel.getFilteredPersonList().contains(userProfile));
+
+        // Undo the deletion
+        deleteCommand.undo(customModel);
+
+        // Verify the original profile was cleanly restored over the placeholder without duplicate exceptions
+        assertTrue(customModel.getFilteredPersonList().contains(userProfile));
+        assertEquals(userProfile, customModel.getUserProfile().get());
+    }
+
+    @Test
+    public void equals_userProfile() {
+        DeleteContactCommand deleteProfile1 = new DeleteContactCommand(null, null, true);
+        DeleteContactCommand deleteProfile2 = new DeleteContactCommand(null, null, true);
+        DeleteContactCommand deleteAlice = new DeleteContactCommand(null, ALICE.getName(), false);
+
+        // same object -> returns true
+        assertTrue(deleteProfile1.equals(deleteProfile1));
+
+        // same values -> returns true
+        assertTrue(deleteProfile1.equals(deleteProfile2));
+
+        // different targeting -> returns false
+        assertFalse(deleteProfile1.equals(deleteAlice));
+        assertFalse(deleteProfile1.equals(null));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/DeleteGameCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteGameCommandTest.java
@@ -129,16 +129,6 @@ public class DeleteGameCommandTest {
     }
 
     @Test
-    public void execute_noProfile_failure() {
-        Model emptyModel = new ModelManager(new AddressBook(), new UserPrefs());
-        Game gameToDelete = new Game("Valorant");
-        DeleteGameCommand deleteGameCommand = new DeleteGameCommand(null, null, gameToDelete, true);
-        emptyModel.deletePerson(emptyModel.getFilteredPersonList().get(0));
-
-        assertCommandFailure(deleteGameCommand, emptyModel, "No user profile found.");
-    }
-
-    @Test
     public void execute_caseInsensitiveName_returnsConfirmation() throws Exception {
         Person firstPerson = model.getFilteredPersonList().get(0);
         Game gameToProcess = new Game("Minecraft");

--- a/src/test/java/seedu/address/logic/commands/EditAliasCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditAliasCommandTest.java
@@ -196,19 +196,6 @@ public class EditAliasCommandTest {
     }
 
     @Test
-    public void execute_noProfile_failure() {
-        Model emptyModel = new ModelManager(new AddressBook(), new UserPrefs());
-        Game game = new Game("Valorant");
-        Alias oldAlias = new Alias("JohnnyV");
-        Alias newAlias = new Alias("JohnnyValorant");
-        emptyModel.deletePerson(emptyModel.getFilteredPersonList().get(0));
-
-        EditAliasCommand editAliasCommand =
-                new EditAliasCommand(null, null, game, oldAlias, newAlias, true);
-        assertCommandFailure(editAliasCommand, emptyModel, "No user profile found.");
-    }
-
-    @Test
     public void undo_editAlias_restoresOriginalAlias() throws Exception {
         Person firstPerson = model.getFilteredPersonList().get(0);
         Game game = new Game("Valorant");

--- a/src/test/java/seedu/address/logic/commands/EditContactCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditContactCommandTest.java
@@ -113,15 +113,6 @@ public class EditContactCommandTest {
     }
 
     @Test
-    public void execute_noUserProfile_throwsCommandException() {
-        Model emptyModel = new ModelManager(new AddressBook(), new UserPrefs());
-        EditContactCommand command = new EditContactCommand(null, null, new Name("Johnny"), true);
-        emptyModel.deletePerson(emptyModel.getFilteredPersonList().get(0));
-
-        assertCommandFailure(command, emptyModel, "No user profile found.");
-    }
-
-    @Test
     public void undo_editContact_restoresOriginalName() throws Exception {
         Person personToEdit = model.getFilteredPersonList().get(0);
         Name originalName = personToEdit.getName();

--- a/src/test/java/seedu/address/logic/commands/ListGameCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListGameCommandTest.java
@@ -111,15 +111,6 @@ public class ListGameCommandTest {
     }
 
     @Test
-    public void execute_noProfile_failure() {
-        Model emptyModel = new ModelManager(new AddressBook(), new UserPrefs());
-        ListGameCommand listGameCommand = new ListGameCommand(null, null, true);
-        emptyModel.deletePerson(emptyModel.getFilteredPersonList().get(0));
-
-        assertCommandFailure(listGameCommand, emptyModel, "No user profile found.");
-    }
-
-    @Test
     public void execute_nullIndexAndName_failure() {
         ListGameCommand listGameCommand = new ListGameCommand(null, null, false);
         assertCommandFailure(listGameCommand, model, ListGameCommand.MESSAGE_CONTACT_NOT_FOUND);

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+import static seedu.address.model.util.GeneratePlaceholder.PLACEHOLDER_PROFILE;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.BENSON;
@@ -30,7 +31,7 @@ public class ModelManagerTest {
         assertEquals(new UserPrefs(), modelManager.getUserPrefs());
         assertEquals(new GuiSettings(), modelManager.getGuiSettings());
         AddressBook ab = new AddressBook();
-        ab.addPerson(new Person(new Name("PLACEHOLDER"), new HashSet<>(), true));
+        ab.addPerson(PLACEHOLDER_PROFILE);
         assertEquals(ab, new AddressBook(modelManager.getAddressBook()));
     }
 


### PR DESCRIPTION
## Type of Change

  - [x] Bug Fix
  - [ ] New Feature
  - [x] Enhancement / Refactor
  - [ ] Documentation
  - [x] Tests

-----

## Description

This PR introduces a robust "self-healing" mechanism to protect the application's "Single Profile at Index 0" architecture. Previously, command `contact delete me` could permanently remove the User Profile, violating core application constraints and breaking subsequent `me` targeted commands. This PR intercepts profile deletions, automatically replaces the deleted profile with a static placeholder, and provides customized UI feedback to the user explaining that their profile was reset.

-----

## Related Issue

Closes #255
Closes #229

-----

## Changes Made

  - **Static Placeholder Utility:** Created `GeneratePlaceholder.PLACEHOLDER_PROFILE` to serve as a single, memory-efficient source of truth for the default User Profile state.
  - **Model-Level Self-Healing:** Updated `ModelManager#deletePerson` to automatically detect when the User Profile is deleted and immediately inject the static placeholder back at index 0.
  - **Customized Deletion Feedback:** Modified `DeleteContactCommand` to return a specific confirmation message ("Your User Profile has been successfully reset to default.") when a user executes `contact delete me`.
  - **Undo Logic Fix:** Enhanced the `undo` logic inside `DeleteContactCommand` to use `setPerson` instead of `addPerson` when restoring a User Profile, safely replacing the auto-generated placeholder without triggering a `DuplicatePersonException`.

-----

## Screenshots / Demo

*(N/A - Logic and CLI output changes)*

-----

## Testing Done

  - [x] Existing tests pass
  - [x] New tests added
  - [x] Manually tested the following scenarios:
    1.  Executed `contact delete me` - Verified the custom success message appeared and the placeholder instantly appeared at the top of the contact list.
    2.  Executed `undo` immediately after resetting the profile - Verified the original profile was successfully restored at index 0 without throwing a duplicate error.

-----

## Checklist

  - [x] Code follows the project's style guidelines
  - [x] Self-reviewed my own code
  - [x] No unnecessary files or debug code included
  - [ ] Relevant documentation updated (e.g. User Guide, Developer Guide)
  - [x] No breaking changes to existing functionality
