### PR TITLE
Fix missing duplicate prefix validation in find, game add, and game delete

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddGameCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddGameCommandParser.java
@@ -26,6 +26,8 @@ public class AddGameCommandParser implements Parser<AddGameCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddGameCommand.MESSAGE_USAGE));
         }
 
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_GAME);
+
         String preamble = argMultimap.getPreamble().trim();
         boolean useUserProfile = preamble.equalsIgnoreCase("me"); // Now checks for 'me'
         boolean hasNamePrefix = argMultimap.getValue(PREFIX_NAME).isPresent();

--- a/src/main/java/seedu/address/logic/parser/DeleteGameCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteGameCommandParser.java
@@ -26,6 +26,8 @@ public class DeleteGameCommandParser implements Parser<DeleteGameCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteGameCommand.MESSAGE_USAGE));
         }
 
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_GAME);
+
         String preamble = argMultimap.getPreamble().trim();
         boolean useUserProfile = preamble.equalsIgnoreCase("me"); // Now checks for 'me'
         boolean hasNamePrefix = argMultimap.getValue(PREFIX_NAME).isPresent();

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -30,6 +30,8 @@ public class FindCommandParser implements Parser<FindCommand> {
     public FindCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(" " + args, PREFIX_GAME, PREFIX_ALIAS);
 
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_GAME, PREFIX_ALIAS);
+
         String preamble = argMultimap.getPreamble().trim();
         Optional<String> gameValue = argMultimap.getValue(PREFIX_GAME);
         Optional<String> aliasValue = argMultimap.getValue(PREFIX_ALIAS);


### PR DESCRIPTION
## Type of Change
- [x] Bug Fix

---

## Description
Three command parsers were missing duplicate prefix validation, causing them to silently accept multiple occurrences of the same prefix and use only the last value. This leads to confusing UX where e.g. `find g/Minecraft g/WoW` appears to succeed but only searches for WoW.

The fix adds `verifyNoDuplicatePrefixesFor()` to the affected parsers, consistent with the existing pattern already used in `AddAliasCommandParser`, `EditAliasCommandParser`, `DeleteAliasCommandParser`, `EditContactCommandParser`, and others.

---

## Related Issue
Closes #251
Closes #257 

---

## Changes Made
- `FindCommandParser`: added duplicate check for `g/` and `al/`
- `AddGameCommandParser`: added duplicate check for `g/` and `n/`
- `DeleteGameCommandParser`: added duplicate check for `g/` and `n/`

---

## Testing Done
- [x] Existing tests pass
- [ ] New tests added
- [x] Manually tested the following scenarios:

### `find` — bugs fixed
| Command | Expected |
|---|---|
| `find g/Minecraft g/WoW` | ERROR (duplicate `g/`) |
| `find al/Ace al/King` | ERROR (duplicate `al/`) |
| `find g/Minecraft al/Ace al/King` | ERROR (duplicate `al/`) |
| `find g/` | ERROR (empty game) |
| `find al/` | ERROR (empty alias) |
| `find` | ERROR (no constraints) |
| `find g/Minecraft` | Returns contacts with Minecraft |
| `find Alice g/Minecraft` | Returns contacts named Alice AND has Minecraft (AND logic) |

### `game add` — bug fixed
| Command | Expected |
|---|---|
| `game add n/Alice g/Minecraft g/WoW` | ERROR (duplicate `g/`) |
| `game add n/Alice n/Bob g/Minecraft` | ERROR (duplicate `n/`) |
| `game add g/Minecraft` | ERROR (no target) |
| `game add me g/Minecraft` | Adds to own profile |
| `game add 1 g/Minecraft` | Adds to contact at index 1 |
| `game add n/Alice g/` | ERROR (empty game name) |
| `game add n/Alice g/Minecraft` | Works normally |

### `game delete` — bug fixed (same missing check as `game add`)
| Command | Expected |
|---|---|
| `game delete n/Alice g/Minecraft g/WoW` | ERROR (duplicate `g/`) |
| `game delete n/Alice n/Bob g/Minecraft` | ERROR (duplicate `n/`) |
| `game delete me g/Minecraft` | Deletes from own profile |
| `game delete me n/Alice g/Minecraft` | ERROR (can't use `n/` with `me`) |
| `game delete n/Alice g/NonExistentGame` | ERROR (game not found) |

### `alias add`
| Command | Expected |
|---|---|
| `alias add n/Alice g/Minecraft g/WoW al/Steve` | ERROR (duplicate `g/`) |
| `alias add n/Alice n/Bob g/Minecraft al/Steve` | ERROR (duplicate `n/`) |
| `alias add n/Alice al/Steve al/King g/Minecraft` | ERROR (duplicate `al/`) |
| `alias add n/Alice g/Minecraft al/` | ERROR (empty alias) |
| `alias add n/Alice g/Minecraft` | ERROR (missing `al/`) |


### `alias edit`
| Command | Expected |
|---|---|
| `alias edit n/Alice g/Minecraft al/OldAlias nal/NewAlias nal/Other` | ERROR (duplicate `nal/`) |
| `alias edit n/Alice g/Minecraft al/NonExistent nal/New` | ERROR (alias not found) |


### `alias delete`
| Command | Expected |
|---|---|
| `alias delete n/Alice g/Minecraft g/WoW al/Steve` | ERROR (duplicate `g/`) |
| `alias delete n/Alice g/Minecraft al/NonExistent` | ERROR (alias not found) |

### `contact add` — intentionally allows multiple `g/` and `al/`
| Command | Expected |
|---|---|
| `add n/Alice g/Minecraft al/Steve g/WoW al/King` | Works (two games, one alias each) |
| `add n/Alice al/Steve g/Minecraft` | ERROR (alias before any game) |
| `add n/Alice n/Bob g/Minecraft` | ERROR (duplicate `n/`) |
| `add n/Alice` | Works (no games) |
| `add n/Alice g/Minecraft g/Minecraft` | Deduplicates (putIfAbsent) |
| `add n/Alice g/Minecraft al/Steve al/Steve` | Deduplicates |
| `add` | ERROR (no name) |

### `contact edit`
| Command | Expected |
|---|---|
| `contact edit n/Alice nn/Bob nn/Charlie` | ERROR (duplicate `nn/`) |
| `contact edit n/Alice n/Bob nn/Charlie` | ERROR (duplicate `n/`) |
| `contact edit me nn/NewName` | Renames own profile |
| `contact edit n/NonExistent nn/Bob` | ERROR (contact not found) |
| `contact edit 1 nn/Bob` | Works |

### `contact delete`
| Command | Expected |
|---|---|
| `contact delete n/Alice n/Bob` | ERROR (duplicate `n/`) |
| `contact delete me n/Alice` | ERROR (can't use `n/` with `me`) |
| `contact delete n/NonExistent` | ERROR (contact not found) |


---

## Checklist
- [x] Code follows the project's style guidelines
- [x] Self-reviewed my own code
- [x] No unnecessary files or debug code included
- [ ] Relevant documentation updated (e.g. User Guide, Developer Guide)
- [x] No breaking changes to existing functionality

---

## Additional Notes
`AddContactCommandParser` intentionally allows multiple `g/` and `al/` prefixes (it builds a game→aliases map per contact), so no change was made there.
