### PR TITLE
Fix view me filtering contact list instead of only showing profile

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ViewContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewContactCommand.java
@@ -80,7 +80,6 @@ public class ViewContactCommand extends Command {
             if (model.getUserProfile().isEmpty()) {
                 throw new CommandException(MESSAGE_NO_PROFILE);
             }
-            model.updateFilteredPersonList(Person::isUserProfile);
             Person userProfile = model.getUserProfile().get();
             return new CommandResult(MESSAGE_SUCCESS_SELF, false, false, userProfile);
         }

--- a/src/test/java/seedu/address/logic/commands/ViewContactCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ViewContactCommandTest.java
@@ -66,21 +66,31 @@ public class ViewContactCommandTest {
 
     @Test
     public void execute_validUserProfile_success() {
-        Person userProfile = model.getFilteredPersonList().get(0);
+        Person userProfile = model.getUserProfile().get();
 
         ViewContactCommand viewContactCommand = new ViewContactCommand(null, null, true);
 
-        // 2. Use the correct success message for the "me" command
         String expectedMessage = ViewContactCommand.MESSAGE_SUCCESS_SELF;
 
-        // 3. Since the command does model.updateFilteredPersonList(Person::isUserProfile);
-        // we must do the same to our expectedModel so they match at the end!
-        expectedModel.updateFilteredPersonList(Person::isUserProfile);
-
+        // view me should NOT filter the contact list — expectedModel remains unchanged
         CommandResult expectedCommandResult = new CommandResult(expectedMessage,
                 false, false, userProfile);
 
         assertCommandSuccess(viewContactCommand, model, expectedCommandResult, expectedModel);
+    }
+
+    @Test
+    public void execute_viewMe_doesNotFilterContactList() {
+        int sizeBefore = model.getFilteredPersonList().size();
+
+        ViewContactCommand viewContactCommand = new ViewContactCommand(null, null, true);
+        try {
+            viewContactCommand.execute(model);
+        } catch (Exception e) {
+            throw new AssertionError("Unexpected exception: " + e.getMessage());
+        }
+
+        assertEquals(sizeBefore, model.getFilteredPersonList().size());
     }
 
     @Test


### PR DESCRIPTION
 ## Type of Change
  - [x] Bug Fix
  - [ ] New Feature
  - [ ] Enhancement / Refactor
  - [ ] Documentation
  - [ ] Tests

  ---

  ## Description
  `view me` was calling `model.updateFilteredPersonList(Person::isUserProfile)`, which permanently filtered the contact list to only show the user profile. This caused all subsequent index/name-based commands (e.g. `view n/Bob`) to fail as the contacts appeared to disappear. The fix removes that filter call so `view me` only displays the profile in the side panel without affecting the contact list.

  ---

  ## Related Issue
  Closes #247 

  ---

  ## Changes Made
  - Removed `model.updateFilteredPersonList(Person::isUserProfile)` from `ViewContactCommand.execute()`
  - Updated existing `execute_validUserProfile_success` test to no longer expect the filter to be applied
  - Added `execute_viewMe_doesNotFilterContactList` regression test to verify the contact list size is unchanged after `view me`


  ---

  ## Testing Done
  - [x] Existing tests pass
  - [x] New tests added
  - [x] Manually tested the following scenarios:
    1. `contact add n/Alice` → `contact add n/Bob` → `view me` → contact list still shows Alice and Bob
    2. `view me` followed by `view n/Bob` succeeds without error

  ---

  ## Checklist
  - [x] Code follows the project's style guidelines
  - [x] Self-reviewed my own code
  - [x] No unnecessary files or debug code included
  - [x] Relevant documentation updated (e.g. User Guide, Developer Guide)
  - [x] No breaking changes to existing functionality

  ---

  ## Additional Notes
  The side panel display of the user profile is handled entirely via the `CommandResult` return value — no list filtering is needed for `view me` to work correctly.
