### PR TITLE
Fix UG inaccuracies: undo list, contact delete 0, and clear description

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -144,14 +144,14 @@ Reverses the most recently executed undoable command.
 
 Format: `undo`
 
-* Undoable commands include: `contact add`, `contact delete`, `contact edit`, `game add`, `game delete`, `alias add`, `alias delete`, and `clear`.
+* Undoable commands include: `contact add`, `contact delete`, `contact edit`, `game add`, `game delete`, `alias add`, `alias edit`, `alias delete`, and `clear`.
 * Multiple consecutive `undo` calls will reverse commands in reverse order of execution.
 * If there are no commands left to undo, an error message is shown.
 
 
 ### Clearing all entries: `clear`
 
-Clears all entries from Harmony.
+Clears all contacts from Harmony. Your own user profile is preserved.
 
 Format: `clear`
 
@@ -296,7 +296,7 @@ Deletes the specified contact from Harmony.
 Format: `contact delete INDEX` or `contact delete n/NAME`
 
 * Deletes the contact at the specified `INDEX` in the displayed list, or whose name matches `NAME` (case-insensitive).
-* `INDEX` must be a positive integer (e.g., 1, 2, 3…​). Note: You can also use `0` to target your own user profile.
+* `INDEX` must be a positive integer (e.g., 1, 2, 3…​).
 * A confirmation prompt will appear. Type `y` or `yes` to confirm, or `n` or `no` to cancel.
 * Any other input cancels the deletion.
 


### PR DESCRIPTION
 ## Type of Change
  - [x] Bug Fix
  - [ ] New Feature
  - [ ] Enhancement / Refactor
  - [x] Documentation
  - [ ] Tests

  ---

  ## Description
  Fixes three inaccuracies in the User Guide where the documentation did not match actual app behaviour.

  ---

  ## Related Issue
  Closes #256
  Closes #239
  Closes #235

  ---

  ## Changes Made
  - Added `alias edit` to the undoable commands list in the undo section (#256)
  - Removed incorrect note stating `contact delete 0` targets the user profile — the app rejects index 0 (#239)
  - Updated `clear` description from "Clears all entries from Harmony" to "Clears all contacts from Harmony. Your own user profile is preserved." (#235)

  ---

  ## Screenshots / Demo
  N/A

  ---

  ## Testing Done
  - [ ] Existing tests pass
  - [ ] New tests added
  - [x] Manually tested the following scenarios:
    1. Verified `alias edit` is now listed under undoable commands
    2. Verified the `contact delete 0` note is removed
    3. Ran `clear` and confirmed user profile persists — description now matches behaviour

  ---

  ## Checklist
  - [x] Code follows the project's style guidelines
  - [x] Self-reviewed my own code
  - [x] No unnecessary files or debug code included
  - [x] Relevant documentation updated (e.g. User Guide, Developer Guide)
  - [x] No breaking changes to existing functionality

  ---

  ## Additional Notes
  All three fixes are documentation-only changes. No code was modified.