### PR TITLE
Fix DG manual testing section referencing non-existent delete command

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -592,13 +592,13 @@ testers are expected to do more *exploratory* testing.
 
    1. Prerequisites: List all persons using the `list` command. Multiple persons in the list.
 
-   2. Test case: `delete 1`<br>
+   2. Test case: `contact delete 1`<br>
       Expected: First contact is deleted from the list. Details of the deleted contact shown in the status message. Timestamp in the status bar is updated.
 
-   3. Test case: `delete 0`<br>
+   3. Test case: `contact delete 0`<br>
       Expected: No person is deleted. Error details shown in the status message. Status bar remains the same.
 
-   4. Other incorrect delete commands to try: `delete`, `delete x`, `...` (where x is larger than the list size)<br>
+   4. Other incorrect delete commands to try: `contact delete`, `contact delete x`, `...` (where x is larger than the list size)<br>
       Expected: Similar to previous.
 
 


### PR DESCRIPTION
## Type of Change
  - [x] Bug Fix
  - [ ] New Feature
  - [ ] Enhancement / Refactor
  - [x] Documentation
  - [ ] Tests

  ---

  ## Description
  The Developer Guide's manual testing section referenced a `delete` command that does not exist in the app. The correct command is `contact delete`. This caused confusion when following the manual testing instructions.

  ---

  ## Related Issue
  Closes #218

  ---

  ## Changes Made
  - Replaced `delete 1` with `contact delete 1`
  - Replaced `delete 0` with `contact delete 0`
  - Replaced `delete`, `delete x` with `contact delete`, `contact delete x` in the incorrect examples list

  ---

  ## Screenshots / Demo
  N/A

  ---

  ## Testing Done
  - [ ] Existing tests pass
  - [ ] New tests added
  - [x] Manually tested the following scenarios:
    1. Followed the updated manual testing instructions — `contact delete 1` works as documented

  ---

  ## Checklist
  - [x] Code follows the project's style guidelines
  - [x] Self-reviewed my own code
  - [x] No unnecessary files or debug code included
  - [x] Relevant documentation updated (e.g. User Guide, Developer Guide)
  - [x] No breaking changes to existing functionality

  ---

  ## Additional Notes
  Documentation-only change. No code was modified.
