### PR TITLE
Fix state details in view panel after delete and clear command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -81,7 +81,7 @@ public class CommandResult {
 
     /** Constructs a {@code CommandResult} that awaits deletion confirmation for the given person. */
     public CommandResult(String feedbackToUser, Person pendingPerson) {
-        this(feedbackToUser, false, false, true, false, requireNonNull(pendingPerson), null, null, false);
+        this(feedbackToUser, false, false, true, false, requireNonNull(pendingPerson), null, pendingPerson, false);
     }
 
     /** Returns a {@code CommandResult} that awaits clear confirmation. */

--- a/src/main/java/seedu/address/logic/commands/ViewContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewContactCommand.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.List;
 import java.util.Objects;
@@ -80,7 +81,7 @@ public class ViewContactCommand extends Command {
             if (model.getUserProfile().isEmpty()) {
                 throw new CommandException(MESSAGE_NO_PROFILE);
             }
-            model.updateFilteredPersonList(Person::isUserProfile);
+            model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
             Person userProfile = model.getUserProfile().get();
             return new CommandResult(MESSAGE_SUCCESS_SELF, false, false, userProfile);
         }

--- a/src/main/java/seedu/address/logic/commands/ViewContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewContactCommand.java
@@ -2,7 +2,6 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.List;
 import java.util.Objects;
@@ -81,7 +80,7 @@ public class ViewContactCommand extends Command {
             if (model.getUserProfile().isEmpty()) {
                 throw new CommandException(MESSAGE_NO_PROFILE);
             }
-            model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+            model.updateFilteredPersonList(Person::isUserProfile);
             Person userProfile = model.getUserProfile().get();
             return new CommandResult(MESSAGE_SUCCESS_SELF, false, false, userProfile);
         }

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -1,7 +1,9 @@
 package seedu.address.ui;
 
+import java.util.Optional;
 import java.util.logging.Logger;
 
+import javafx.collections.ListChangeListener;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.scene.Scene;
@@ -17,6 +19,7 @@ import seedu.address.logic.Logic;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.Person;
 
 /**
  * The Main Window. Provides the basic application layout containing
@@ -36,6 +39,7 @@ public class MainWindow extends UiPart<Stage> {
     private ResultDisplay resultDisplay;
     private HelpWindow helpWindow;
     private ViewPanel viewPanel;
+    private Person currentlyViewedPerson = null;
 
     @FXML
     private StackPane commandBoxPlaceholder;
@@ -130,6 +134,35 @@ public class MainWindow extends UiPart<Stage> {
 
         viewPanel = new ViewPanel();
         viewPanelPlaceholder.getChildren().add(viewPanel.getRoot());
+
+        bindViewPanelToModel();
+    }
+    /**
+     * Passively listens to the database for any changes (edits, deletions, undos).
+     * If the currently viewed person is modified, it updates the ViewPanel automatically.
+     */
+    private void bindViewPanelToModel() {
+        // Listen to the master list of all contacts
+        logic.getFilteredPersonList().addListener((ListChangeListener<Person>) change -> {
+
+            if (currentlyViewedPerson != null && !currentlyViewedPerson.isUserProfile()) {
+
+                // Find if our viewed person is still in the newly updated list
+                Optional<Person> updatedPerson = logic.getFilteredPersonList().stream()
+                        .filter(p -> p.isSamePerson(currentlyViewedPerson))
+                        .findFirst();
+
+                if (updatedPerson.isEmpty()) {
+                    // They were deleted or undone!
+                    viewPanel.clearPerson();
+                    currentlyViewedPerson = null;
+                } else {
+                    // They were edited (e.g., a game was added)! Refresh the panel.
+                    currentlyViewedPerson = updatedPerson.get();
+                    viewPanel.setPerson(currentlyViewedPerson);
+                }
+            }
+        });
     }
 
     /**
@@ -189,8 +222,10 @@ public class MainWindow extends UiPart<Stage> {
 
             if (commandResult.isClearView()) {
                 viewPanel.clearPerson();
+                currentlyViewedPerson = null;
             } else if (commandResult.getViewedPerson() != null) {
                 viewPanel.setPerson(commandResult.getViewedPerson());
+                currentlyViewedPerson = commandResult.getViewedPerson();
             }
 
             if (commandResult.isShowHelp()) {

--- a/src/test/java/seedu/address/logic/commands/CommandResultTest.java
+++ b/src/test/java/seedu/address/logic/commands/CommandResultTest.java
@@ -105,7 +105,7 @@ public class CommandResultTest {
         assertEquals(person, commandResult.getPendingPerson());
         assertFalse(commandResult.isShowHelp());
         assertFalse(commandResult.isExit());
-        assertNull(commandResult.getViewedPerson());
+        assertEquals(person, commandResult.getViewedPerson());
     }
 
     @Test


### PR DESCRIPTION
## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [x] Enhancement / Refactor
- [ ] Documentation
- [ ] Tests

---

## Description
This PR addresses UI state synchronization issues and improves the Quality of Life (QoL) for contact management. It introduces a reactive architectural pattern for the `ViewPanel` so it automatically stays in sync with backend data changes (like undo operations or edits). It also enhances the deletion confirmation workflow by allowing users to visually verify the contact they are modifying before confirming.

---

## Related Issue
Closes #240
Closes #198 

---

## Changes Made

### 1. Reactive ViewPanel Synchronization (`MainWindow.java`)
- Implemented the Observer Pattern by adding a `ListChangeListener` to the `FilteredPersonList`. 
- The `ViewPanel` now passively listens for database changes. If the currently viewed person is edited (e.g., game added) or deleted/undone, the panel will automatically refresh with the new data or safely clear itself, eliminating "stale state" UI bugs.

### 2. Pre-Deletion Visual Confirmation (`CommandResult.java` & Deletion Commands)
- Fixed the 2-argument constructor in `CommandResult.java` used for `y/n` confirmations so it correctly populates the `personToView` field without breaking the parser's confirmation flag.
- Commands like `DeleteAliasCommand` now instantly snap the `ViewPanel` open to the target contact the moment the `y/n` confirmation text appears, allowing the user to visually verify the profile they are about to modify.

---

## Screenshots / Demo
NIL

---

## Testing Done
- [x] Passed Checkstyle (`./gradlew check`)
- [x] Existing JUnit tests pass 
- [ ] New tests added
- [x] Manually tested the following scenarios:
  1. Initiated a `delete alias` command and verified the `ViewPanel` opens instantly while the CLI waits for `y/n`.
  2. Verified the `y/n` parser still functions correctly after the UI update.
  3. Executed an `undo` operation and verified the `ViewPanel` reacts accordingly (refreshes if edited, clears if deleted).

---

## Checklist
- [x] Code follows the project's style guidelines
- [x] Self-reviewed my own code
- [x] No unnecessary files or debug code included
- [ ] Relevant documentation updated (e.g. Developer Guide for the new Observer pattern)
- [x] No breaking changes to existing functionality