### PR TITLE
Clarify alias matching is game-independent in find

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -285,8 +285,8 @@ Format: `find [KEYWORD]…​ [g/GAME_NAME] [al/ALIAS]`
 
 Examples:
 * `find Alice g/Valorant` returns contacts named `Alice` who have `Valorant` in their game list.
-* `find g/Valorant al/Ace` returns contacts who play `Valorant` with the alias `Ace`.
-* `find Alice g/Valorant al/Ace` returns contacts named `Alice` who play `Valorant` with the alias `Ace`.
+* `find g/Valorant al/Ace` returns contacts who play `Valorant` and have an alias called `Ace` (alias can be associated with any game, not necessarily `Valorant`).
+* `find Alice g/Valorant al/Ace` returns contacts named `Alice` who play `Valorant` and have an alias called `Ace` (alias can be associated with any game, not necessarily `Valorant`).
 
 
 ### Deleting a contact: `contact delete`


### PR DESCRIPTION
## Type of Change
- [ ] Bug Fix
- [ ] New Feature
- [ ] Enhancement / Refactor
- [x] Documentation
- [ ] Tests

---
## Description
Fix misleading User Guide examples for the find command. The current examples imply that `al/` matches aliases specific to the game in `g/`, but alias matching is actually independent of game filtering.

---
## Related Issue
Closes #232 

---
## Changes Made
- Update find command example descriptions in User Guide
- Clarify that a matched alias can be associated with any game, not necessarily the one specified with `g/`

---
## Screenshots / Demo
N/A

---
## Testing Done
- [x] Existing tests pass
- [ ] New tests added
- [x] Manually tested the following scenarios:
  1. Reviewed updated documentation for accuracy
  2. Verified find command behaviour matches updated descriptions

---
## Checklist
- [x] Code follows the project's style guidelines
- [x] Self-reviewed my own code
- [x] No unnecessary files or debug code included
- [x] Relevant documentation updated (e.g. User Guide, Developer Guide)
- [x] No breaking changes to existing functionality

---
## Additional Notes
This is a documentation clarification only — no code changes. The find command behaviour remains the same; only the User Guide descriptions are updated to accurately reflect how alias and game filtering work independently.