### PR TITLE
Fix undo rejecting extraneous arguments

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -114,7 +114,7 @@ Harmony is a **desktop app for managing contacts and their gaming aliases, optim
 * Prefixed parameters (those using `n/`, `g/`, `al/`, etc.) can be in any order.<br>
   e.g. `alias add n/John Doe g/Valorant al/JohnV` and `alias add g/Valorant n/John Doe al/JohnV` are both acceptable.
 
-* Extraneous parameters for commands that do not take in parameters (such as `help`, `list`, `exit` and `clear`) will be ignored.<br>
+* Extraneous parameters for commands that do not take in parameters (such as `help`, `list`, `undo`, `clear` and `exit`) will be ignored.<br>
   e.g. `help 123` will be interpreted as `help`.
 
 * If you are using a PDF version of this document, be careful when copying and pasting commands that span multiple lines as space characters surrounding line-breaks may be omitted when copied over to the application.

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -65,7 +65,7 @@ public class LogicManager implements Logic {
         }
 
         CommandResult commandResult;
-        Command command = commandText.trim().equals(UndoCommand.COMMAND_WORD)
+        Command command = commandText.trim().split("\\s+")[0].equals(UndoCommand.COMMAND_WORD)
                 ? new UndoCommand(commandHistory)
                 : addressBookParser.parseCommand(commandText);
         commandResult = command.execute(model);


### PR DESCRIPTION
## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Enhancement / Refactor
- [x] Documentation
- [ ] Tests

---
## Description
Fix undo command rejecting extraneous arguments. Previously, inputs like `undo 123` failed to match and were treated as unknown commands. The undo command now ignores extra arguments, consistent with clear, help, and exit.

---
## Related Issue
Closes #252 

---
## Changes Made
- Fix undo command to split on whitespace and check only the first token
- Consistent behaviour with how clear, help, and exit handle extra input
- Update User Guide to add undo to the list of commands that ignore extraneous parameters

---
## Screenshots / Demo
N/A

---
## Testing Done
- [x] Existing tests pass
- [ ] New tests added
- [x] Manually tested the following scenarios:
  1. `undo` — works as expected
  2. `undo 123` — now works (previously treated as unknown command)
  3. `undo abc xyz` — now works, ignores extra arguments

---
## Checklist
- [x] Code follows the project's style guidelines
- [x] Self-reviewed my own code
- [x] No unnecessary files or debug code included
- [x] Relevant documentation updated (e.g. User Guide, Developer Guide)
- [x] No breaking changes to existing functionality

---
## Additional Notes
This fix aligns undo behaviour with other commands (clear, help, exit) that ignore extraneous parameters. Users are now correctly informed in the User Guide.