### PR TITLE
Update DG addressing multiple inaccuracies

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -44,8 +44,7 @@ The bulk of the app's work is done by the following four components:
 
 **How the architecture components interact with each other**
 
-The *Sequence Diagram* below shows how the components interact with each other for the scenario where the user issues the command `delete 1`.
-
+The *Sequence Diagram* below shows how the components interact with each other for the scenario where the user issues the command `contact delete 1`.
 <puml src="diagrams/ArchitectureSequenceDiagram.puml" width="574" />
 
 Each of the four main components (also shown in the diagram above),
@@ -84,23 +83,25 @@ Here's a (partial) class diagram of the `Logic` component:
 
 <puml src="diagrams/LogicClassDiagram.puml" width="550"/>
 
-The sequence diagram below illustrates the interactions within the `Logic` component, taking `execute("delete 1")` API call as an example.
+The sequence diagram below illustrates the interactions within the `Logic` component, taking `execute("contact delete 1")` API call as an example.
 
-<puml src="diagrams/DeleteSequenceDiagram.puml" alt="Interactions Inside the Logic Component for the `delete 1` Command" />
+<puml src="diagrams/DeleteSequenceDiagram.puml" alt="Interactions Inside the Logic Component for the `contact delete 1` Command" />
 
 <box type="info" seamless>
 
-**Note:** The lifeline for `DeleteCommandParser` should end at the destroy marker (X) but due to a limitation of PlantUML, the lifeline continues till the end of diagram.
+**Note:** The lifeline for `DeleteContactCommandParser` should end at the destroy marker (X) but due to a limitation of PlantUML, the lifeline continues till the end of diagram.
 </box>
 
 How the `Logic` component works:
 
-1. When `Logic` is called upon to execute a command, it is passed to an `AddressBookParser` object which in turn creates a parser that matches the command (e.g., `DeleteCommandParser`) and uses it to parse the command.
-1. This results in a `Command` object (more precisely, an object of one of its subclasses e.g., `DeleteCommand`) which is executed by the `LogicManager`.
-1. The command can communicate with the `Model` when it is executed (e.g. to delete a person).<br>
-   Note that although this is shown as a single step in the diagram above (for simplicity), in the code it can take several interactions (between the command object and the `Model`) to achieve.
-1. The result of the command execution is encapsulated as a `CommandResult` object which is returned back from `Logic`.
-1. If the command implements the `UndoableCommand` interface, `LogicManager` pushes it onto the `commandHistory` stack so it can be reversed by a subsequent `undo` command.
+How the `Logic` component works:
+
+1. When `Logic` is called upon to execute a command, it is passed to an `AddressBookParser` object which in turn creates a parser that matches the command (e.g., `DeleteContactCommandParser`) and uses it to parse the command.
+2. This results in a `Command` object (more precisely, an object of one of its subclasses e.g., `DeleteContactCommand`) which is executed by the `LogicManager`.
+3. The command can communicate with the `Model` when it is executed (e.g. to delete a person).<br>
+   Note that although this is shown as a single step in the diagram above (for simplicity), in the code it can take several interactions (between the command object and the `Model`) to achieve. 
+4. The result of the command execution is encapsulated as a `CommandResult` object which is returned back from `Logic`. 
+5. If the command implements the `UndoableCommand` interface, `LogicManager` pushes it onto the `commandHistory` stack so it can be reversed by a subsequent `undo` command.
 
 Here are the other classes in `Logic` (omitted from the class diagram above) that are used for parsing a user command:
 
@@ -108,8 +109,7 @@ Here are the other classes in `Logic` (omitted from the class diagram above) tha
 
 How the parsing works:
 * When called upon to parse a user command, the `AddressBookParser` class creates an `XYZCommandParser` (`XYZ` is a placeholder for the specific command name e.g., `AddCommandParser`) which uses the other classes shown above to parse the user command and create a `XYZCommand` object (e.g., `AddCommand`) which the `AddressBookParser` returns back as a `Command` object.
-* All `XYZCommandParser` classes (e.g., `AddCommandParser`, `DeleteCommandParser`, ...) inherit from the `Parser` interface so that they can be treated similarly where possible e.g, during testing.
-
+* All `XYZCommandParser` classes (e.g., `AddCommandParser`, `DeleteContactCommandParser`, ...) inherit from the `Parser` interface so that they can be treated similarly where possible e.g., during testing.
 ### Model component
 **API** : [`Model.java`](https://github.com/se-edu/addressbook-level3/tree/master/src/main/java/seedu/address/model/Model.java)
 
@@ -154,7 +154,7 @@ Classes used by multiple components are in the `seedu.address.commons` package.
 This section describes some noteworthy details on how certain features are implemented.
 
 ### Copy Command Feature
-The `copy` command allows users to quickly serialize a specific contact's complex profile (including their name, tags, games, and aliases) into a perfectly formatted, executable CLI string (e.g., `contact add n/John Doe t/friend...`) and saves it directly to their operating system's clipboard.
+The `copy` command allows users to quickly serialize a specific contact's complex profile (including their name, games, and aliases) into a perfectly formatted, executable CLI string (e.g., `contact add n/John Doe g/Valorant...`) and saves it directly to their operating system's clipboard.
 
 #### Architecture and Execution
 To avoid cluttering the main logic architecture diagram, the structural relationship of the `CopyCommand` is shown in the feature-specific class diagram below.
@@ -226,7 +226,7 @@ The `contact edit` command allows users to rename an existing contact while pres
    * If `targetIndex` is set, retrieves the person at that index from the filtered list.
    * If `targetName` is set, searches `model.getFilteredPersonList()` for a case-insensitive name match.
 2. If not found, a `CommandException` with `MESSAGE_PERSON_NOT_FOUND` is thrown.
-3. A new `Person` is created with `newName` and the original person's `tags`, `games`, and `isUserProfile` flag.
+3. A new `Person` is created with `newName` and the original person's `games`, and `isUserProfile` flag.
 4. If the new name already belongs to a different person, a `CommandException` with `MESSAGE_DUPLICATE_PERSON` is thrown.
 5. `model.setPerson()` replaces the old entry, and the filtered list is reset to show all persons.
 6. A `CommandResult` is returned, displaying the updated contact.
@@ -577,7 +577,7 @@ testers are expected to do more *exploratory* testing.
 
    1. Download the jar file and copy into an empty folder
 
-   2. Double-click the jar file Expected: Shows the GUI with a set of sample contacts. The window size may not be optimum.
+   2. Double-click the jar file Expected: Shows the GUI with a placeholder User Profile. The window size may not be optimum.
 
 2. Saving window preferences
 
@@ -592,10 +592,10 @@ testers are expected to do more *exploratory* testing.
 
    1. Prerequisites: List all persons using the `list` command. Multiple persons in the list.
 
-   2. Test case: `delete 1`<br>
+   2. Test case: `contact delete 1`<br>
       Expected: First contact is deleted from the list. Details of the deleted contact shown in the status message. Timestamp in the status bar is updated.
 
-   3. Test case: `delete 0`<br>
+   3. Test case: `contact delete 0`<br>
       Expected: No person is deleted. Error details shown in the status message. Status bar remains the same.
 
    4. Other incorrect delete commands to try: `delete`, `delete x`, `...` (where x is larger than the list size)<br>

--- a/docs/diagrams/ArchitectureSequenceDiagram.puml
+++ b/docs/diagrams/ArchitectureSequenceDiagram.puml
@@ -8,10 +8,10 @@ Participant ":Logic" as logic LOGIC_COLOR
 Participant ":Model" as model MODEL_COLOR
 Participant ":Storage" as storage STORAGE_COLOR
 
-user -[USER_COLOR]> ui : "delete 1"
+user -[USER_COLOR]> ui : "contact delete 1"
 activate ui UI_COLOR
 
-ui -[UI_COLOR]> logic : execute("delete 1")
+ui -[UI_COLOR]> logic : execute("contact delete 1")
 activate logic LOGIC_COLOR
 
 logic -[LOGIC_COLOR]> model : deletePerson(p)

--- a/docs/diagrams/DeleteCommandClassDiagram.puml
+++ b/docs/diagrams/DeleteCommandClassDiagram.puml
@@ -8,10 +8,8 @@ package Logic {
 
 Class "{abstract}\nCommand" as Command
 Class "<<interface>>\nUndoableCommand" as UndoableCommand
-<<<<<<< HEAD
 Class "<<interface>>\nConfirmableDeleteCommand" as ConfirmableDeleteCommand
-=======
->>>>>>> upstream/master
+
 Class LogicManager
 Class DeleteContactCommand
 Class DeleteGameCommand
@@ -23,7 +21,6 @@ DeleteContactCommand -up-|> Command
 DeleteGameCommand -up-|> Command
 DeleteAliasCommand -up-|> Command
 
-<<<<<<< HEAD
 DeleteContactCommand .up.|> ConfirmableDeleteCommand
 DeleteGameCommand .up.|> ConfirmableDeleteCommand
 DeleteAliasCommand .up.|> ConfirmableDeleteCommand
@@ -39,18 +36,6 @@ note bottom of ConfirmableDeleteCommand
   Decoupled from UndoableCommand.
   Future commands may implement only
   one of the two interfaces.
-=======
-DeleteContactCommand .up.|> UndoableCommand
-DeleteGameCommand .up.|> UndoableCommand
-DeleteAliasCommand .up.|> UndoableCommand
-
-LogicManager .right.> Command : <<call>>
-LogicManager --> DeleteContactCommand : stores for confirmation
-
-note right of DeleteContactCommand
-  execute() returns a confirmation prompt.
-  Deletion only occurs after user types "y".
->>>>>>> upstream/master
 end note
 
 @enduml

--- a/docs/diagrams/DeleteConfirmSequenceDiagram.puml
+++ b/docs/diagrams/DeleteConfirmSequenceDiagram.puml
@@ -22,11 +22,7 @@ note right : Finds person,\ndoes NOT delete yet
 DeleteCommand --> LogicManager : CommandResult\n(isAwaitingConfirmation=true)
 deactivate DeleteCommand
 
-<<<<<<< HEAD
 note over LogicManager : Stores command in\npendingConfirmableCommand
-=======
-note over LogicManager : Stores pending person and command,\nshows confirmation prompt to user
->>>>>>> upstream/master
 
 [<-- LogicManager : "Are you sure? (y/n)"
 deactivate LogicManager
@@ -36,7 +32,6 @@ deactivate LogicManager
 [-> LogicManager : execute("y")
 activate LogicManager
 
-<<<<<<< HEAD
 LogicManager -> DeleteCommand : performDeletion(m)
 activate DeleteCommand
 DeleteCommand -> Model : delete person
@@ -47,14 +42,6 @@ DeleteCommand --> LogicManager : CommandResult (success)
 deactivate DeleteCommand
 
 note over LogicManager : If command implements UndoableCommand,\npush to commandHistory
-=======
-LogicManager -> Model : delete person
-activate Model
-Model --> LogicManager
-deactivate Model
-
-note over LogicManager : Pushes command to\ncommandHistory for undo
->>>>>>> upstream/master
 
 [<-- LogicManager : "Contact deleted: Alice"
 deactivate LogicManager


### PR DESCRIPTION
## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Enhancement / Refactor
- [x] Documentation
- [ ] Tests

---

## Description
This PR addresses multiple inaccuracies in the Developer Guide (DG) to ensure it accurately reflects Harmony's current implementation and command structures. It also resolves Git merge conflict markers that were breaking the rendering of our PlantUML diagrams. 

---

## Related Issues
Closes #224
Closes #234
Closes #237
Closes #246

---

## Changes Made

### 1. PlantUML Rendering Fix (#224)
- Removed lingering Git merge conflict markers (`<<<<<<< HEAD`, etc.) in `ArchitectureSequenceDiagram.puml`, `DeleteSequenceDiagram.puml`, and other affected `.puml` files.
- Ensured diagrams now render correctly and reflect the new `ConfirmableDeleteCommand` architecture.

### 2. Manual Testing Updates (#246 & #237)
- **Delete Command:** Updated the manual testing instructions for deleting a person. Changed the obsolete `delete 1` command to the correct `contact delete 1` syntax.
- **Initial Launch:** Corrected the expected behavior for the initial launch test. It now accurately states that the app shows a "placeholder User Profile" instead of "sample contacts."

### 3. Copy Command Documentation Fix (#234)
- Removed outdated references to "tags" and the `t/` prefix in the `CopyCommand` implementation section of the DG.
- Updated the description to accurately reflect Harmony's current model, which serializes a contact's `games` and `aliases` instead of tags.

---

## Checklist
- [x] Documentation reflects current application behavior
- [x] PlantUML diagrams successfully generate without syntax errors
- [x] Self-reviewed my own changes
- [x] Passed Checkstyle (`./gradlew check`)