### PR TITLE
Add tests for duplicate parameters check

### DIFF
--- a/src/test/java/seedu/address/logic/parser/AddGameCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddGameCommandParserTest.java
@@ -1,6 +1,9 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.Messages.MESSAGE_DUPLICATE_FIELDS;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_GAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
@@ -82,5 +85,17 @@ public class AddGameCommandParserTest {
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddGameCommand.MESSAGE_USAGE));
         assertParseFailure(parser, "  ",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddGameCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_duplicateGamePrefix_throwsParseException() {
+        assertParseFailure(parser, " n/Zi Xuan g/Minecraft g/WoW",
+                MESSAGE_DUPLICATE_FIELDS + PREFIX_GAME);
+    }
+
+    @Test
+    public void parse_duplicateNamePrefix_throwsParseException() {
+        assertParseFailure(parser, " n/Zi Xuan n/Alice g/Minecraft",
+                MESSAGE_DUPLICATE_FIELDS + PREFIX_NAME);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/DeleteGameCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteGameCommandParserTest.java
@@ -1,6 +1,9 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.Messages.MESSAGE_DUPLICATE_FIELDS;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_GAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
@@ -81,5 +84,17 @@ public class DeleteGameCommandParserTest {
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteGameCommand.MESSAGE_USAGE));
         assertParseFailure(parser, "  ",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteGameCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_duplicateGamePrefix_throwsParseException() {
+        assertParseFailure(parser, " n/Zi Xuan g/Minecraft g/WoW",
+                MESSAGE_DUPLICATE_FIELDS + PREFIX_GAME);
+    }
+
+    @Test
+    public void parse_duplicateNamePrefix_throwsParseException() {
+        assertParseFailure(parser, " n/Zi Xuan n/Alice g/Minecraft",
+                MESSAGE_DUPLICATE_FIELDS + PREFIX_NAME);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -1,12 +1,18 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.Messages.MESSAGE_DUPLICATE_FIELDS;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ALIAS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_GAME;
 
 import java.util.Arrays;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.parser.exceptions.ParseException;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.model.person.AliasMatchesPredicate;
@@ -115,5 +121,24 @@ public class FindCommandParserTest {
     public void parse_emptyAliasInCombined_throwsParseException() {
         assertParseFailure(parser, "Alice al/",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_duplicateGamePrefix_throwsParseException() {
+        assertParseFailure(parser, "g/Minecraft g/WoW",
+                MESSAGE_DUPLICATE_FIELDS + PREFIX_GAME);
+    }
+
+    @Test
+    public void parse_duplicateAliasPrefix_throwsParseException() {
+        assertParseFailure(parser, "al/Ace al/King",
+                MESSAGE_DUPLICATE_FIELDS + PREFIX_ALIAS);
+    }
+
+    @Test
+    public void parse_duplicateGameAndAliasPrefix_throwsParseException() {
+        // Both g/ and al/ are duplicated — exact message order is non-deterministic (Set),
+        // so we only assert that a ParseException is thrown
+        Assertions.assertThrows(ParseException.class, () -> parser.parse("g/Minecraft g/WoW al/Ace al/King"));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -2,19 +2,18 @@ package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_DUPLICATE_FIELDS;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
-import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ALIAS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_GAME;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
 import java.util.Arrays;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import seedu.address.logic.parser.exceptions.ParseException;
-
 import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.AliasMatchesPredicate;
 import seedu.address.model.person.GameContainsKeywordPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;


### PR DESCRIPTION
## Type of Change
- [x] Tests

---

## Description
Adds missing duplicate prefix test cases to `FindCommandParserTest`, `AddGameCommandParserTest`, and `DeleteGameCommandParserTest`, corresponding to the duplicate prefix validation fixes added in the previous PR.

---

## Related Issue


---

## Changes Made
- `FindCommandParserTest`: added `parse_duplicateGamePrefix_throwsParseException`, `parse_duplicateAliasPrefix_throwsParseException`, `parse_duplicateGameAndAliasPrefix_throwsParseException`
- `AddGameCommandParserTest`: added `parse_duplicateGamePrefix_throwsParseException`, `parse_duplicateNamePrefix_throwsParseException`
- `DeleteGameCommandParserTest`: added `parse_duplicateGamePrefix_throwsParseException`, `parse_duplicateNamePrefix_throwsParseException`

---

## Testing Done
- [x] Existing tests pass
- [x] New tests added
- [ ] Manually tested the following scenarios:

---

## Checklist
- [x] Code follows the project's style guidelines
- [x] Self-reviewed my own code
- [x] No unnecessary files or debug code included
- [ ] Relevant documentation updated (e.g. User Guide, Developer Guide)
- [x] No breaking changes to existing functionality

---

## Additional Notes
For `parse_duplicateGameAndAliasPrefix_throwsParseException` in `FindCommandParserTest`, `assertThrows` is used instead of `assertParseFailure` because when both `g/` and `al/` are duplicated simultaneously, the error message joins them from a `HashSet` — order is non-deterministic, making exact message assertion unreliable. The single-prefix duplicate tests already verify the message format.
