### PR TITLE
Find command: require n/ prefix for name search

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -19,13 +19,13 @@ public class FindCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons matching ALL the given search "
             + "criteria (case-insensitive) and displays them as a list with index numbers.\n"
-            + "Parameters: [KEYWORD MORE_KEYWORDS...] [g/GAME_NAME] [al/ALIAS]\n"
+            + "Parameters: [n/NAME] [g/GAME_NAME] [al/ALIAS]\n"
             + "At least one constraint must be provided. Multiple constraints are combined with AND logic.\n"
-            + "Example: " + COMMAND_WORD + " alice pauline\n"
+            + "Example: " + COMMAND_WORD + " n/Alice\n"
             + "Example: " + COMMAND_WORD + " g/Valorant\n"
             + "Example: " + COMMAND_WORD + " al/BenJumpin\n"
-            + "Example: " + COMMAND_WORD + " alice g/Valorant\n"
-            + "Example: " + COMMAND_WORD + " alice g/Valorant al/BenJumpin";
+            + "Example: " + COMMAND_WORD + " n/Alice g/Valorant\n"
+            + "Example: " + COMMAND_WORD + " n/Alice g/Valorant al/BenJumpin";
 
     private final Predicate<Person> predicate;
 

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -3,8 +3,9 @@ package seedu.address.logic.parser;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ALIAS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_GAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 
-import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
 
@@ -28,18 +29,21 @@ public class FindCommandParser implements Parser<FindCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public FindCommand parse(String args) throws ParseException {
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(" " + args, PREFIX_GAME, PREFIX_ALIAS);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(" " + args, PREFIX_NAME, PREFIX_GAME, PREFIX_ALIAS);
 
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_GAME, PREFIX_ALIAS);
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_GAME, PREFIX_ALIAS);
 
-        String preamble = argMultimap.getPreamble().trim();
+        Optional<String> nameValue = argMultimap.getValue(PREFIX_NAME);
         Optional<String> gameValue = argMultimap.getValue(PREFIX_GAME);
         Optional<String> aliasValue = argMultimap.getValue(PREFIX_ALIAS);
 
-        boolean hasName = !preamble.isEmpty();
+        boolean hasName = nameValue.isPresent() && !nameValue.get().trim().isEmpty();
         boolean hasGame = gameValue.isPresent() && !gameValue.get().isEmpty();
         boolean hasAlias = aliasValue.isPresent() && !aliasValue.get().isEmpty();
 
+        if (nameValue.isPresent() && !hasName) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        }
         if (gameValue.isPresent() && !hasGame) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
@@ -52,8 +56,7 @@ public class FindCommandParser implements Parser<FindCommand> {
 
         // Single constraint — return specific predicate type for clean equality semantics
         if (hasName && !hasGame && !hasAlias) {
-            String[] nameKeywords = preamble.split("\\s+");
-            return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+            return new FindCommand(new NameContainsKeywordsPredicate(List.of(nameValue.get().trim())));
         }
         if (!hasName && hasGame && !hasAlias) {
             return new FindCommand(new GameContainsKeywordPredicate(gameValue.get()));
@@ -65,8 +68,7 @@ public class FindCommandParser implements Parser<FindCommand> {
         // Multiple constraints — AND all predicates together
         Predicate<Person> combined = person -> true;
         if (hasName) {
-            String[] nameKeywords = preamble.split("\\s+");
-            combined = combined.and(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+            combined = combined.and(new NameContainsKeywordsPredicate(List.of(nameValue.get().trim())));
         }
         if (hasGame) {
             combined = combined.and(new GameContainsKeywordPredicate(gameValue.get()));

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -7,8 +7,8 @@ import static seedu.address.logic.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
-import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -54,17 +54,7 @@ public class FindCommandTest {
     }
 
     @Test
-    public void execute_zeroKeywords_noPersonFound() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
-        NameContainsKeywordsPredicate predicate = preparePredicate(" ");
-        FindCommand command = new FindCommand(predicate);
-        expectedModel.updateFilteredPersonList(predicate);
-        assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(expectedModel.getFilteredPersonList(), model.getFilteredPersonList());
-    }
-
-    @Test
-    public void execute_multipleKeywords_singlePersonFound() {
+    public void execute_nameSubstring_singlePersonFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 1);
         NameContainsKeywordsPredicate predicate = preparePredicate("Carl Kurz");
         FindCommand command = new FindCommand(predicate);
@@ -74,7 +64,7 @@ public class FindCommandTest {
     }
 
     @Test
-    public void execute_multipleKeywords_noPersonFound() {
+    public void execute_nameSubstring_noPersonFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
         NameContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle");
         FindCommand command = new FindCommand(predicate);
@@ -105,7 +95,7 @@ public class FindCommandTest {
 
     @Test
     public void toStringMethod() {
-        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(Arrays.asList("keyword"));
+        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(List.of("keyword"));
         FindCommand findCommand = new FindCommand(predicate);
         String expected = FindCommand.class.getCanonicalName() + "{predicate=" + predicate + "}";
         assertEquals(expected, findCommand.toString());
@@ -115,6 +105,6 @@ public class FindCommandTest {
      * Parses {@code userInput} into a {@code NameContainsKeywordsPredicate}.
      */
     private NameContainsKeywordsPredicate preparePredicate(String userInput) {
-        return new NameContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
+        return new NameContainsKeywordsPredicate(List.of(userInput.trim()));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -7,9 +7,7 @@ import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
-import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
@@ -119,10 +117,8 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_find() throws Exception {
-        List<String> keywords = Arrays.asList("foo", "bar", "baz");
-        FindCommand command = (FindCommand) parser.parseCommand(
-                FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
-        assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), command);
+        FindCommand command = (FindCommand) parser.parseCommand(FindCommand.COMMAND_WORD + " n/foo");
+        assertEquals(new FindCommand(new NameContainsKeywordsPredicate(List.of("foo"))), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -4,7 +4,7 @@ import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
-import java.util.Arrays;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -25,11 +25,23 @@ public class FindCommandParserTest {
     @Test
     public void parse_validNameArgs_returnsFindCommand() {
         FindCommand expectedFindCommand =
-                new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
-        assertParseSuccess(parser, "Alice Bob", expectedFindCommand);
+                new FindCommand(new NameContainsKeywordsPredicate(List.of("Alice")));
+        assertParseSuccess(parser, "n/Alice", expectedFindCommand);
 
-        // multiple whitespaces between keywords
-        assertParseSuccess(parser, " \n Alice \n \t Bob  \t", expectedFindCommand);
+        // with leading whitespace
+        assertParseSuccess(parser, " n/Alice", expectedFindCommand);
+    }
+
+    @Test
+    public void parse_validNameArgsMultiWord_returnsFindCommand() {
+        FindCommand expectedFindCommand =
+                new FindCommand(new NameContainsKeywordsPredicate(List.of("Alice Bob")));
+        assertParseSuccess(parser, "n/Alice Bob", expectedFindCommand);
+    }
+
+    @Test
+    public void parse_emptyNamePrefix_throwsParseException() {
+        assertParseFailure(parser, "n/", String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
     }
 
     @Test
@@ -62,10 +74,9 @@ public class FindCommandParserTest {
 
     @Test
     public void parse_nameAndGameCombined_returnsFindCommand() {
-        // Combined name + game returns a non-null FindCommand without throwing
         FindCommand result = null;
         try {
-            result = parser.parse("Alice g/Valorant");
+            result = parser.parse("n/Alice g/Valorant");
         } catch (Exception e) {
             org.junit.jupiter.api.Assertions.fail("Parsing combined name and game should not throw: " + e.getMessage());
         }
@@ -76,7 +87,7 @@ public class FindCommandParserTest {
     public void parse_nameAndAliasCombined_returnsFindCommand() {
         FindCommand result = null;
         try {
-            result = parser.parse("Alice al/BenJumpin");
+            result = parser.parse("n/Alice al/BenJumpin");
         } catch (Exception e) {
             org.junit.jupiter.api.Assertions.fail("Should not throw: " + e.getMessage());
         }
@@ -98,7 +109,7 @@ public class FindCommandParserTest {
     public void parse_allThreeCombined_returnsFindCommand() {
         FindCommand result = null;
         try {
-            result = parser.parse("Alice g/Valorant al/BenJumpin");
+            result = parser.parse("n/Alice g/Valorant al/BenJumpin");
         } catch (Exception e) {
             org.junit.jupiter.api.Assertions.fail("Parsing all three constraints should not throw: " + e.getMessage());
         }
@@ -107,13 +118,13 @@ public class FindCommandParserTest {
 
     @Test
     public void parse_emptyGameInCombined_throwsParseException() {
-        assertParseFailure(parser, "Alice g/",
+        assertParseFailure(parser, "n/Alice g/",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
     }
 
     @Test
     public void parse_emptyAliasInCombined_throwsParseException() {
-        assertParseFailure(parser, "Alice al/",
+        assertParseFailure(parser, "n/Alice al/",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
     }
 }


### PR DESCRIPTION
## Type of Change
- [ ] Bug Fix
- [ ] New Feature
- [x] Enhancement / Refactor
- [ ] Documentation
- [ ] Tests

---
## Description
Update the find command to use `n/` prefix for name search instead of preamble keywords. This makes the syntax consistent with all other commands that use `n/` for name and aligns with how `g/` and `al/` work.

---
## Related Issue
Closes #226 

---
## Changes Made
- Update find command parser to use `n/` prefix for name search
- Match the full string after the prefix as a substring, consistent with `g/` and `al/`
- Remove preamble keyword handling for name search

---
## Screenshots / Demo
N/A

---
## Testing Done
- [x] Existing tests pass
- [ ] New tests added
- [x] Manually tested the following scenarios:
  1. `find n/david` — returns contacts with names containing "david"
  2. `find n/dav` — returns contacts with names containing "dav"
  3. `find n/david g/mine` — returns contacts matching both name and game
  4. `find n/david g/mine al/player` — combined search works correctly

---
## Checklist
- [x] Code follows the project's style guidelines
- [x] Self-reviewed my own code
- [x] No unnecessary files or debug code included
- [ ] Relevant documentation updated (e.g. User Guide, Developer Guide)
- [x] No breaking changes to existing functionality

---
## Additional Notes
This is a syntax change for the find command. Previous syntax `find KEYWORD` is replaced with `find n/KEYWORD`. This improves consistency across the application as all other commands use `n/` for name fields.