### PR TITLE
Update exit message to reference Harmony

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExitCommand.java
@@ -9,7 +9,7 @@ public class ExitCommand extends Command {
 
     public static final String COMMAND_WORD = "exit";
 
-    public static final String MESSAGE_EXIT_ACKNOWLEDGEMENT = "Exiting Address Book as requested ...";
+    public static final String MESSAGE_EXIT_ACKNOWLEDGEMENT = "Exiting Harmony as requested ...";
 
     @Override
     public CommandResult execute(Model model) {


### PR DESCRIPTION
## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Enhancement / Refactor
- [ ] Documentation
- [ ] Tests

---
## Description
Update exit command message to reference "Harmony" instead of the old product name "Address Book".

---
## Related Issue
Closes #243 

---
## Changes Made
- Update `ExitCommand` exit message from "Address Book" to "Exiting Harmony as requested ..."

---
## Screenshots / Demo
N/A 

---
## Testing Done
- [x] Existing tests pass
- [ ] New tests added
- [x] Manually tested the following scenarios:
  1. Run `exit` command — displays "Exiting Harmony as requested ..."

---
## Checklist
- [x] Code follows the project's style guidelines
- [x] Self-reviewed my own code
- [x] No unnecessary files or debug code included
- [ ] Relevant documentation updated (e.g. User Guide, Developer Guide)
- [x] No breaking changes to existing functionality

---
## Additional Notes
Simple text update to reflect the correct product name.