### PR TITLE
Replace mentions of Address Book with Contact List

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddContactCommand.java
@@ -18,7 +18,7 @@ public class AddContactCommand extends Command implements UndoableCommand {
 
     public static final String COMMAND_WORD = "contact add";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to the address book. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to the contact list. "
             + "Parameters: "
             + PREFIX_NAME + "NAME "
             + "[" + PREFIX_GAME + "GAME] "
@@ -31,7 +31,7 @@ public class AddContactCommand extends Command implements UndoableCommand {
             + PREFIX_GAME + "Minecraft";
 
     public static final String MESSAGE_SUCCESS = "Contact added: %1$s";
-    public static final String MESSAGE_DUPLICATE_PERSON = "Error: Contact already exists in the address book";
+    public static final String MESSAGE_DUPLICATE_PERSON = "Error: Contact already exists in the contact list";
 
     private final Person toAdd;
 

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -15,7 +15,7 @@ import seedu.address.model.person.Person;
 public class ClearCommand extends Command implements UndoableCommand {
 
     public static final String COMMAND_WORD = "clear";
-    public static final String MESSAGE_SUCCESS = "Address book has been cleared!";
+    public static final String MESSAGE_SUCCESS = "contact list has been cleared!";
     public static final String MESSAGE_CONFIRMATION = "Are you sure you want to clear all contacts? (y/n)";
     public static final String MESSAGE_CANCELLED = "Clear cancelled.";
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -30,7 +30,7 @@ public class ModelManager implements Model {
     public ModelManager(ReadOnlyAddressBook addressBook, ReadOnlyUserPrefs userPrefs) {
         requireAllNonNull(addressBook, userPrefs);
 
-        logger.fine("Initializing with address book: " + addressBook + " and user prefs " + userPrefs);
+        logger.fine("Initializing with contact list: " + addressBook + " and user prefs " + userPrefs);
 
         this.addressBook = new AddressBook(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);


### PR DESCRIPTION
## Type of Change

  - [ ] Bug Fix
  - [ ] New Feature
  - [x] Enhancement / Refactor
  - [x] Documentation
  - [ ] Tests

-----

## Description

This PR updates the application's domain language by replacing legacy "address book" terminology with "contact list". This ensures consistency with Harmony's identity as a gaming contact manager. The changes specifically update the user-facing feedback messages for the `contact add` and `clear` commands, as well as internal string literals and exceptions within the `ModelManager`.

-----

## Related Issue

Closes #275 

-----

## Changes Made

  - Updated `MESSAGE_SUCCESS` in `ClearCommand.java` to state that the "contact list" has been cleared.
  - Updated `MESSAGE_USAGE` in `AddContactCommand.java`  to warn that the contact already exists in the "contact list".
  - Replaced internal string literals, logs, and exception messages within `ModelManager.java` to use "contact list" instead of "address book".
 
-----

## Screenshots / Demo

*(N/A - Text string updates only)*

-----

## Testing Done

  - [x] Existing tests pass
  - [ ] New tests added (updated existing test assertions)
  - [x] Manually tested the following scenarios:
    1.  Executed `clear` via the CLI and verified the success message outputs "Contact list has been cleared\!".
    2.  Executed a `contact add` command with details of an existing contact and verified the error message outputs "This contact already exists in the contact list".

-----

## Checklist

  - [x] Code follows the project's style guidelines
  - [x] Self-reviewed my own code
  - [x] No unnecessary files or debug code included
  - [ ] Relevant documentation updated (e.g. User Guide, Developer Guide)
  - [x] No breaking changes to existing functionality