### PR TITLE
Fix misleading DG command history description and add UG navigation tip

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -194,8 +194,14 @@ To improve the Quality of Life (QoL) of the CLI interface, users can navigate th
 The command history state is managed directly within the `CommandBox` UI component. Because the history is only relevant to the current user session and involves direct manipulation of the JavaFX text field and caret position, a lightweight, self-contained implementation was chosen to minimize unnecessary dependencies between the UI and Logic components.
 
 The state is tracked using two internal variables:
-* `commandHistory`: An `ArrayList` storing the string values of previously executed commands.
+* `commandHistory`: An `ArrayList` storing the string values of previously submitted commands.
 * `historyPointer`: An integer tracking the user's current index during navigation.
+
+<box type="info" seamless>
+
+Commands are added to `commandHistory` **before** execution is attempted. This means commands that fail (e.g. due to invalid input) are still stored and accessible via the Up arrow. This is intentional — it allows users to quickly retrieve and correct a malformed command without retyping it.
+
+</box>
 
 Step-by-step execution for navigating backwards:
 1. The user presses the Up arrow key while focused on the text field.


### PR DESCRIPTION
## Type of Change
- [ ] Bug Fix
- [ ] New Feature
- [ ] Enhancement / Refactor
- [x] Documentation
- [ ] Tests

---
## Description
Fix misleading documentation about command history and add missing documentation for the Up/Down arrow navigation feature.

---
## Related Issue
N/A

---
## Changes Made
**Developer Guide:**
- Fix "previously executed" to "previously submitted" in CommandBox description
- Add info box clarifying that failed commands are stored in history and why

---
## Screenshots / Demo
N/A

---
## Testing Done
- [x] Existing tests pass
- [ ] New tests added
- [x] Manually tested the following scenarios:
  1. Entered a failed command, pressed Up arrow — failed command appears (confirms behaviour matches updated docs)
  2. Navigated through command history using Up/Down arrows — works as documented

---
## Checklist
- [x] Code follows the project's style guidelines
- [x] Self-reviewed my own code
- [x] No unnecessary files or debug code included
- [x] Relevant documentation updated (e.g. User Guide, Developer Guide)
- [x] No breaking changes to existing functionality

---
## Additional Notes
CommandBox stores commands before execution, so failed commands are included in history. The DG previously said "previously executed" which was misleading.